### PR TITLE
[항공사 웹사이트의 컴포넌트 접근성 높이기 - 2단계] 우연(전연지) 미션 제출합니다.

### DIFF
--- a/a11y-airline/package-lock.json
+++ b/a11y-airline/package-lock.json
@@ -13,6 +13,7 @@
         "@types/react-dom": "^18.0.6",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-icons": "^4.4.0",
         "react-scripts": "5.0.1",
         "styled-components": "^5.3.6",
         "typescript": "^4.8.4"
@@ -13747,6 +13748,14 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
     },
+    "node_modules/react-icons": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.4.0.tgz",
+      "integrity": "sha512-fSbvHeVYo/B5/L4VhB7sBA1i2tS8MkT0Hb9t2H1AVPkwGfVHLJCqyr2Py9dKMxsyM63Eng1GkdZfbWj+Fmv8Rg==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -26244,6 +26253,12 @@
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
+    },
+    "react-icons": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.4.0.tgz",
+      "integrity": "sha512-fSbvHeVYo/B5/L4VhB7sBA1i2tS8MkT0Hb9t2H1AVPkwGfVHLJCqyr2Py9dKMxsyM63Eng1GkdZfbWj+Fmv8Rg==",
+      "requires": {}
     },
     "react-is": {
       "version": "17.0.2",

--- a/a11y-airline/package.json
+++ b/a11y-airline/package.json
@@ -9,6 +9,7 @@
     "@types/react-dom": "^18.0.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-icons": "^4.4.0",
     "react-scripts": "5.0.1",
     "styled-components": "^5.3.6",
     "typescript": "^4.8.4"

--- a/a11y-airline/src/App.tsx
+++ b/a11y-airline/src/App.tsx
@@ -1,9 +1,10 @@
-import { PassengerSelection } from "components";
+import { PassengerSelection, Carousel } from "components";
 
 function App() {
   return (
     <main>
-      <PassengerSelection />
+      {/* <PassengerSelection /> */}
+      <Carousel />
     </main>
   );
 }

--- a/a11y-airline/src/components/Carousel/index.tsx
+++ b/a11y-airline/src/components/Carousel/index.tsx
@@ -1,0 +1,135 @@
+import { FlexBox, CarouselItem } from "components";
+import { CarouselItemProps } from "components/CarouselItem/type";
+import { travelList } from "constants/index";
+import styled, { css } from "styled-components";
+import { IoIosArrowBack, IoIosArrowForward } from "react-icons/io";
+import { useState, useEffect } from "react";
+import useActiveElement from "hooks/useActiveElement";
+
+const MOVE_COUNT = {
+  MIN: 0,
+  MAX: travelList.length - 5,
+};
+
+export const Carousel = () => {
+  const [moveCount, setMoveCount] = useState(0);
+  const focusedElement = useActiveElement("li");
+
+  useEffect(() => {
+    if (focusedElement && focusedElement.parentNode) {
+      let currentFocusIndex = Array.prototype.indexOf.call(
+        focusedElement.parentNode.children,
+        focusedElement
+      );
+
+      if (currentFocusIndex < MOVE_COUNT.MIN) {
+        currentFocusIndex = MOVE_COUNT.MIN;
+      }
+      if (currentFocusIndex > MOVE_COUNT.MAX) {
+        currentFocusIndex = MOVE_COUNT.MAX;
+      }
+
+      setMoveCount(currentFocusIndex);
+    }
+  }, [focusedElement]);
+
+  const isLeftButtonDisabled = moveCount <= MOVE_COUNT.MIN;
+  const isRightButtonDisabled = moveCount >= MOVE_COUNT.MAX;
+
+  const handleCarouselButton = (direction: "left" | "right") => {
+    if (direction === "left") {
+      if (isLeftButtonDisabled) {
+        return;
+      }
+      setMoveCount((prev) => prev - 1);
+      return;
+    }
+    if (isRightButtonDisabled) {
+      return;
+    }
+    setMoveCount((prev) => prev + 1);
+  };
+
+  return (
+    <FlexBox flexDirection="column" gap="0.5rem">
+      <h1>지금 떠나기 좋은 여행</h1>
+      <Slider>
+        <Content as="ul" moveCount={moveCount} gap="0.5rem">
+          {travelList.map((travelItem: CarouselItemProps, index) => (
+            <li key={index}>
+              <CarouselItem {...travelItem} />
+            </li>
+          ))}
+        </Content>
+        <LeftButton
+          onClick={() => handleCarouselButton("left")}
+          aria-disabled={isLeftButtonDisabled}
+          isDisabled={isLeftButtonDisabled}
+          aria-label="이전 항목"
+        >
+          <IoIosArrowBack size={23} />
+        </LeftButton>
+        <RightButton
+          onClick={() => handleCarouselButton("right")}
+          aria-disabled={isRightButtonDisabled}
+          isDisabled={isRightButtonDisabled}
+          aria-label="다음 항목"
+        >
+          <IoIosArrowForward size={23} />
+        </RightButton>
+      </Slider>
+    </FlexBox>
+  );
+};
+
+const Slider = styled.div`
+  width: 52rem;
+  overflow: hidden;
+  position: relative;
+`;
+
+type ContentProps = {
+  moveCount: number;
+};
+
+const Content = styled(FlexBox)<ContentProps>`
+  ${({ moveCount }) => css`
+    transition: all 1s;
+    transform: translateX(calc(${moveCount} * -10.5rem));
+  `}
+`;
+
+type CarouselButtonProps = {
+  isDisabled: boolean;
+};
+
+const CarouselButton = styled.button.attrs({
+  type: "button",
+})<CarouselButtonProps>`
+  ${({ isDisabled }) => css`
+    box-sizing: border-box;
+    width: 3rem;
+    height: 3rem;
+    border-radius: 50%;
+    position: absolute;
+    background-color: rgba(0, 0, 0, 0.6);
+    color: white;
+    line-height: 3rem;
+    padding: 0.25rem;
+
+    ${isDisabled &&
+    css`
+      cursor: not-allowed;
+    `}
+  `}
+`;
+
+const LeftButton = styled(CarouselButton)`
+  transform: translate3d(-50%, -8rem, 0);
+  text-align: end;
+`;
+
+const RightButton = styled(CarouselButton)`
+  transform: translate3d(calc(52rem - 50%), -8rem, 0);
+  text-align: start;
+`;

--- a/a11y-airline/src/components/Carousel/index.tsx
+++ b/a11y-airline/src/components/Carousel/index.tsx
@@ -8,7 +8,7 @@ import useActiveElement from "hooks/useActiveElement";
 
 const MOVE_COUNT = {
   MIN: 0,
-  MAX: travelList.length - 5,
+  MAX: travelList.length - 2,
 };
 
 export const Carousel = () => {
@@ -87,7 +87,7 @@ export const Carousel = () => {
 };
 
 const Slider = styled.div`
-  width: 52rem;
+  width: 20.5rem;
   overflow: hidden;
   position: relative;
 `;
@@ -134,6 +134,6 @@ const LeftButton = styled(CarouselButton)`
 `;
 
 const RightButton = styled(CarouselButton)`
-  transform: translate3d(calc(52rem - 50%), -8rem, 0);
+  transform: translate3d(calc(20.5rem - 50%), -8rem, 0);
   text-align: start;
 `;

--- a/a11y-airline/src/components/Carousel/index.tsx
+++ b/a11y-airline/src/components/Carousel/index.tsx
@@ -55,7 +55,7 @@ export const Carousel = () => {
   };
 
   return (
-    <FlexBox flexDirection="column" gap="0.5rem">
+    <FlexBox as="section" flexDirection="column" gap="0.5rem">
       <h1>지금 떠나기 좋은 여행</h1>
       <Slider>
         <Content as="ul" moveCount={moveCount} gap="0.5rem">

--- a/a11y-airline/src/components/Carousel/index.tsx
+++ b/a11y-airline/src/components/Carousel/index.tsx
@@ -16,7 +16,11 @@ export const Carousel = () => {
   const focusedElement = useActiveElement("li");
 
   useEffect(() => {
-    if (focusedElement && focusedElement.parentNode) {
+    if (
+      focusedElement &&
+      focusedElement.tagName === "LI" &&
+      focusedElement.parentNode
+    ) {
       let currentFocusIndex = Array.prototype.indexOf.call(
         focusedElement.parentNode.children,
         focusedElement

--- a/a11y-airline/src/components/CarouselItem/index.tsx
+++ b/a11y-airline/src/components/CarouselItem/index.tsx
@@ -1,0 +1,62 @@
+import { FlexBox, Hidden } from "components";
+import { CarouselItemProps } from "./type";
+import styled from "styled-components";
+
+export const CarouselItem = ({
+  place,
+  seat,
+  minCost,
+  link,
+  placeImg,
+}: CarouselItemProps) => {
+  const costRange = `KRW ${minCost.toLocaleString()} ~`;
+  const screenReaderCost = `${minCost.toLocaleString()} 대한민국 원`;
+  const screenReaderPlace = place.replace("-", "");
+
+  return (
+    <a href={link}>
+      <TravelItem>
+        <TravelImgContainer>
+          <img src={placeImg} alt="" />
+        </TravelImgContainer>
+        <TravelDescContainer flexDirection="column" gap="0.3rem">
+          <Hidden>{screenReaderPlace}</Hidden>
+          <p aria-hidden="true">{place}</p>
+          <p>{seat}</p>
+          <Hidden>{screenReaderCost}</Hidden>
+          <p aria-hidden="true">{costRange}</p>
+        </TravelDescContainer>
+      </TravelItem>
+    </a>
+  );
+};
+
+const TravelItem = styled.div`
+  width: 10rem;
+  height: 13rem;
+  position: relative;
+`;
+
+const TravelImgContainer = styled.div`
+  overflow: hidden;
+  margin: 0 auto;
+
+  & img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+`;
+
+const TravelDescContainer = styled(FlexBox)`
+  width: 10rem;
+  position: absolute;
+  left: 0;
+  top: 0;
+  padding: 0.5rem 0.6rem;
+  p {
+    overflow: hidden;
+    /* text-overflow: ellipsis; */
+    /* white-space: nowrap; */
+  }
+`;

--- a/a11y-airline/src/components/CarouselItem/type.ts
+++ b/a11y-airline/src/components/CarouselItem/type.ts
@@ -1,0 +1,7 @@
+export type CarouselItemProps = {
+  place: string;
+  seat: string;
+  minCost: number;
+  link: string;
+  placeImg: string;
+};

--- a/a11y-airline/src/components/Hidden/index.tsx
+++ b/a11y-airline/src/components/Hidden/index.tsx
@@ -1,0 +1,10 @@
+import styled from "styled-components";
+
+export const Hidden = styled.p`
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  clip: rect(0 0 0 0);
+  margin: -1px;
+  overflow: hidden;
+`;

--- a/a11y-airline/src/components/PassengerSelection/index.tsx
+++ b/a11y-airline/src/components/PassengerSelection/index.tsx
@@ -1,4 +1,4 @@
-import { FlexBox } from "components";
+import { FlexBox, Hidden } from "components";
 import { ChangeEventHandler, useRef, useState } from "react";
 import styled, { css } from "styled-components";
 
@@ -158,15 +158,6 @@ const Passenger = styled.input`
   font-size: 1.4rem;
   font-weight: bold;
   border-bottom: 0.5px solid black;
-`;
-
-const Hidden = styled.p`
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  clip: rect(0 0 0 0);
-  margin: -1px;
-  overflow: hidden;
 `;
 
 const CloseButton = styled.button.attrs({

--- a/a11y-airline/src/components/index.ts
+++ b/a11y-airline/src/components/index.ts
@@ -1,2 +1,5 @@
 export * from "components/FlexBox";
+export * from "components/Hidden";
 export * from "components/PassengerSelection";
+export * from "components/Carousel";
+export * from "components/CarouselItem";

--- a/a11y-airline/src/constants/index.ts
+++ b/a11y-airline/src/constants/index.ts
@@ -1,0 +1,67 @@
+export const travelList = [
+  {
+    place: "서울/인천 - 두바이",
+    seat: "일반석 왕복",
+    minCost: 1121600,
+    link: "https://www.koreanair.com/booking/best-prices?departureCode=ICN&destinationCode=DXB&duration=7&cabin=Y",
+    placeImg:
+      "https://www.koreanair.com/content/dam/koreanair/ko/airport-img/DXB-list-pc.jpg",
+  },
+  {
+    place: "서울/인천 - 후쿠오카",
+    seat: "일반석 왕복",
+    minCost: 340400,
+    link: "https://www.koreanair.com/booking/best-prices?departureCode=ICN&destinationCode=FUK&cabin=Y&tripType=RT&duration=7",
+    placeImg:
+      "	https://www.koreanair.com/content/dam/koreanair/ko/airport-img/FUK-list-pc.jpg",
+  },
+
+  {
+    place: "서울/인천 - 푸껫",
+    seat: "일반석 왕복",
+    minCost: 704200,
+    link: "https://www.koreanair.com/booking/best-prices?departureCode=ICN&destinationCode=HKT&cabin=Y&tripType=RT&duration=7",
+    placeImg:
+      "https://www.koreanair.com/content/dam/koreanair/ko/airport-img/HKT-list-pc.jpg",
+  },
+  {
+    place: "서울/인천 - 치앙마이",
+    seat: "일반석 왕복",
+    minCost: 839200,
+    link: "https://www.koreanair.com/booking/best-prices?departureCode=ICN&destinationCode=CNX&cabin=Y&tripType=RT&duration=7",
+    placeImg:
+      "https://www.koreanair.com/content/dam/koreanair/ko/airport-img/CNX-list-pc.jpg",
+  },
+  {
+    place: "서울/인천 - 바르셀로",
+    seat: "일반석 왕복",
+    minCost: 1546300,
+    link: "https://www.koreanair.com/booking/best-prices?departureCode=ICN&destinationCode=BCN&cabin=Y&tripType=RT&duration=7",
+    placeImg:
+      "https://www.koreanair.com/content/dam/koreanair/ko/airport-img/BCN-list-pc.jpg",
+  },
+  {
+    place: "서울/인천 - 하노이",
+    seat: "일반석 왕복",
+    minCost: 1121600,
+    link: "https://www.koreanair.com/booking/best-prices?departureCode=ICN&destinationCode=HAN&cabin=Y&tripType=RT&duration=7",
+    placeImg:
+      "https://www.koreanair.com/content/dam/koreanair/ko/airport-img/HAN-list-pc.jpg",
+  },
+  {
+    place: "서울/인천-로마/레오나르도 다빈치",
+    seat: "일반석 왕복",
+    minCost: 1454300,
+    link: "https://www.koreanair.com/booking/best-prices?departureCode=ICN&destinationCode=FCO&cabin=Y&tripType=RT&duration=7",
+    placeImg:
+      "https://www.koreanair.com/content/dam/koreanair/ko/airport-img/FCO-list-pc.jpg",
+  },
+  {
+    place: "서울/인천-호놀룰루 (하와이)",
+    seat: "일반석 왕복",
+    minCost: 1244900,
+    link: "https://www.koreanair.com/booking/best-prices?departureCode=ICN&destinationCode=HNL&cabin=Y&tripType=RT&duration=7",
+    placeImg:
+      "https://www.koreanair.com/content/dam/koreanair/ko/airport-img/HNL-list-pc.jpg",
+  },
+];

--- a/a11y-airline/src/hooks/useActiveElement.ts
+++ b/a11y-airline/src/hooks/useActiveElement.ts
@@ -1,21 +1,21 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 
 const useActiveElement = (selectors: string) => {
   const [active, setActive] = useState(document.activeElement);
 
-  const handleFocusIn = () => {
+  const handleFocusIn = useCallback(() => {
     const focusElement = document.activeElement?.closest(selectors);
     if (focusElement) {
       setActive(focusElement);
     }
-  };
+  }, [selectors]);
 
   useEffect(() => {
     document.addEventListener("focusin", handleFocusIn);
     return () => {
       document.removeEventListener("focusin", handleFocusIn);
     };
-  }, []);
+  }, [handleFocusIn]);
 
   return active;
 };

--- a/a11y-airline/src/hooks/useActiveElement.ts
+++ b/a11y-airline/src/hooks/useActiveElement.ts
@@ -1,0 +1,23 @@
+import { useState, useEffect } from "react";
+
+const useActiveElement = (selectors: string) => {
+  const [active, setActive] = useState(document.activeElement);
+
+  const handleFocusIn = () => {
+    const focusElement = document.activeElement?.closest(selectors);
+    if (focusElement) {
+      setActive(focusElement);
+    }
+  };
+
+  useEffect(() => {
+    document.addEventListener("focusin", handleFocusIn);
+    return () => {
+      document.removeEventListener("focusin", handleFocusIn);
+    };
+  }, []);
+
+  return active;
+};
+
+export default useActiveElement;

--- a/a11y-airline/src/styles/GlobalStyle.ts
+++ b/a11y-airline/src/styles/GlobalStyle.ts
@@ -111,7 +111,8 @@ ${({ theme }) => css`
     font-family: "Source Sans Pro", sans-serif;
   }
   ol,
-  ul {
+  ul,
+  li {
     list-style: none;
   }
   blockquote,


### PR DESCRIPTION
## 🔥 결과

직접 구현한 페이지를 작동시켜볼 수 있도록 접근 가능한 페이지 링크를 공유해주세요.

[링크](https://ronci.github.io/a11y-airline/)

## ✅ 요구사항 목록

**2 Carousel**

- [x] 총 8개의 carousel 중 2개의 목록을 기본으로 보여준다.
- [x] 실제 스크린 리더는 아래와 같이 읽을 수 있어야 합니다. 단, 스크린 리더기 마다 읽는 방법이 다를 수 있으니 참고만 해주세요. 중요한건 스크린 리더기를 활용하여 동작을 할 수 있어야 합니다.
- [x] 리팩터링 과정에서 불필요하거나 웹 표준에 어긋나는 마크업은 없는지 확인합니다.

```
1. 지금 떠나기 좋은 여행
2. 목록 8개 항목 포함 서울/인천 로스앤젤레스 일반석 왕복 1,481,800 대한민국 원 링크 목록 항목
3. 다음 버튼 (사용 중지)
4. 이전 버튼 (사용 중지)
```

## 🧐 공유

저는 focus가 오면 focus에 맞춰 carousel가 자동으로 움직일 수 있도록 `useActiveElement`를 사용했습니다!
이 훅에서는focus된 element에서 selectors와 일치하는 가장 가까운 조상 또는 자기 자신을 반환하는 훅입니다
이 훅을 사용해서 focus된 요소를 알아오고 그것에 대한 index를 알아오는 방식으로 carousel을 자동으로 이동시켰습니다.

참고자료 : [How to find focused React component? (like document.activeElement)](https://stackoverflow.com/questions/58886782/how-to-find-focused-react-component-like-document-activeelement)