### PR TITLE
[항공사 웹사이트의 컴포넌트 접근성 높이기 - 2단계] 무비(변영화) 미션 제출합니다.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@types/react-dom": "^18.0.6",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-router-dom": "^6.4.2",
         "react-scripts": "5.0.1",
         "typescript": "^4.8.4",
         "web-vitals": "^2.1.4"
@@ -3760,6 +3761,14 @@
         "webpack-plugin-serve": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.0.2.tgz",
+      "integrity": "sha512-GRSOFhJzjGN+d4sKHTMSvNeUPoZiDHWmRnXfzaxrqe7dE/Nzlc8BiMSJdLDESZlndM7jIUrZ/F4yWqVYlI0rwQ==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -26016,6 +26025,36 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.4.2.tgz",
+      "integrity": "sha512-Rb0BAX9KHhVzT1OKhMvCDMw776aTYM0DtkxqUBP8dNBom3mPXlfNs76JNGK8wKJ1IZEY1+WGj+cvZxHVk/GiKw==",
+      "dependencies": {
+        "@remix-run/router": "1.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.4.2.tgz",
+      "integrity": "sha512-yM1kjoTkpfjgczPrcyWrp+OuQMyB1WleICiiGfstnQYo/S8hPEEnVjr/RdmlH6yKK4Tnj1UGXFSa7uwAtmDoLQ==",
+      "dependencies": {
+        "@remix-run/router": "1.0.2",
+        "react-router": "6.4.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
     "node_modules/react-scripts": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-5.0.1.tgz",
@@ -33852,6 +33891,11 @@
         "schema-utils": "^3.0.0",
         "source-map": "^0.7.3"
       }
+    },
+    "@remix-run/router": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.0.2.tgz",
+      "integrity": "sha512-GRSOFhJzjGN+d4sKHTMSvNeUPoZiDHWmRnXfzaxrqe7dE/Nzlc8BiMSJdLDESZlndM7jIUrZ/F4yWqVYlI0rwQ=="
     },
     "@rollup/plugin-babel": {
       "version": "5.3.1",
@@ -50628,6 +50672,23 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A=="
+    },
+    "react-router": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.4.2.tgz",
+      "integrity": "sha512-Rb0BAX9KHhVzT1OKhMvCDMw776aTYM0DtkxqUBP8dNBom3mPXlfNs76JNGK8wKJ1IZEY1+WGj+cvZxHVk/GiKw==",
+      "requires": {
+        "@remix-run/router": "1.0.2"
+      }
+    },
+    "react-router-dom": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.4.2.tgz",
+      "integrity": "sha512-yM1kjoTkpfjgczPrcyWrp+OuQMyB1WleICiiGfstnQYo/S8hPEEnVjr/RdmlH6yKK4Tnj1UGXFSa7uwAtmDoLQ==",
+      "requires": {
+        "@remix-run/router": "1.0.2",
+        "react-router": "6.4.2"
+      }
     },
     "react-scripts": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@types/react-dom": "^18.0.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-router-dom": "^6.4.2",
     "react-scripts": "5.0.1",
     "typescript": "^4.8.4",
     "web-vitals": "^2.1.4"

--- a/src/App.style.ts
+++ b/src/App.style.ts
@@ -6,4 +6,5 @@ export const Container = styled.main`
   display: flex;
   justify-content: center;
   align-items: center;
+  overflow: hidden;
 `;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,19 @@
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { Global } from '@emotion/react';
+
 import PassengetSelector from './components/PassengerSeletor';
 import globalStyle from './globalStyle';
 import * as S from './App.style';
 
 function App() {
   return (
-    <S.Container aria-label="승객 선택을 위한 서비스">
-      <PassengetSelector />
+    <S.Container>
+      <BrowserRouter basename="/a11y-airline">
+        <Routes>
+          <Route path="/" element={<PassengetSelector />} />
+        </Routes>
+      </BrowserRouter>
+
       <Global styles={globalStyle} />
     </S.Container>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,8 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { Global } from '@emotion/react';
 
 import PassengetSelector from './components/PassengerSeletor';
+import DiscoverNow from './components/DiscoverNow';
+
 import globalStyle from './globalStyle';
 import * as S from './App.style';
 
@@ -10,7 +12,8 @@ function App() {
     <S.Container>
       <BrowserRouter basename="/a11y-airline">
         <Routes>
-          <Route path="/" element={<PassengetSelector />} />
+          <Route path="/" element={<DiscoverNow />} />
+          <Route path="/step1" element={<PassengetSelector />} />
         </Routes>
       </BrowserRouter>
 

--- a/src/components/Carousel/components/Item/index.stories.tsx
+++ b/src/components/Carousel/components/Item/index.stories.tsx
@@ -1,0 +1,15 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import Item from '.';
+import { trips } from '../../../../dummy';
+
+export default {
+  title: 'Components/Item',
+  component: Item,
+} as ComponentMeta<typeof Item>;
+
+const Template: ComponentStory<typeof Item> = args => <Item {...args} />;
+
+export const ItemTemplate = Template.bind({});
+ItemTemplate.args = {
+  ...trips[0],
+};

--- a/src/components/Carousel/components/Item/index.style.ts
+++ b/src/components/Carousel/components/Item/index.style.ts
@@ -1,0 +1,42 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.a`
+  text-decoration: none;
+  color: black;
+  position: relative;
+
+  width: 230px;
+  height: 300px;
+  display: flex;
+
+  p {
+    margin: 0;
+  }
+`;
+
+export const Content = styled.img`
+  width: 230px;
+  height: 300px;
+  border-radius: 5px;
+`;
+
+export const Description = styled.div`
+  position: absolute;
+  padding: 3px 10px;
+`;
+
+export const Title = styled.h2`
+  font-size: 14px;
+`;
+
+export const SubTitle = styled.p`
+  font-size: 12px;
+`;
+
+export const Information = styled.p`
+  font-size: 14px;
+  font-weight: 700;
+  color: #11277b;
+  text-shadow: -0.5px 0 #fff, 0 0.5px #fff, 0.5px 0 #fff, 0 -0.5px #fff;
+  padding: 5px 0px;
+`;

--- a/src/components/Carousel/components/Item/index.tsx
+++ b/src/components/Carousel/components/Item/index.tsx
@@ -1,7 +1,7 @@
 import { HTMLAttributes } from 'react';
 import * as S from './index.style';
 
-interface ItemProps extends HTMLAttributes<HTMLAnchorElement> {
+export interface ItemProps extends HTMLAttributes<HTMLAnchorElement> {
   link: string;
   imgSrc: string;
   description: {

--- a/src/components/Carousel/components/Item/index.tsx
+++ b/src/components/Carousel/components/Item/index.tsx
@@ -1,0 +1,27 @@
+import { HTMLAttributes } from 'react';
+import * as S from './index.style';
+
+interface ItemProps extends HTMLAttributes<HTMLAnchorElement> {
+  link: string;
+  imgSrc: string;
+  description: {
+    title: string;
+    subTitle: string;
+    information: string;
+  };
+}
+
+const Item = ({ link, imgSrc, description, ...props }: ItemProps) => {
+  return (
+    <S.Container href={link} {...props}>
+      <S.Content src={imgSrc} alt={description.title} />
+      <S.Description>
+        <S.Title>{description.title}</S.Title>
+        <S.SubTitle>{description.subTitle}</S.SubTitle>
+        <S.Information>{description.information}</S.Information>
+      </S.Description>
+    </S.Container>
+  );
+};
+
+export default Item;

--- a/src/components/Carousel/components/Item/index.tsx
+++ b/src/components/Carousel/components/Item/index.tsx
@@ -6,8 +6,11 @@ export interface ItemProps extends HTMLAttributes<HTMLAnchorElement> {
   imgSrc: string;
   description: {
     title: string;
+    titleLabel?: string;
     subTitle: string;
+    subTitleLabel?: string;
     information: string;
+    informationLabel?: string;
   };
 }
 
@@ -16,9 +19,15 @@ const Item = ({ link, imgSrc, description, ...props }: ItemProps) => {
     <S.Container href={link} {...props}>
       <S.Content src={imgSrc} />
       <S.Description>
-        <S.Title>{description.title}</S.Title>
-        <S.SubTitle>{description.subTitle}</S.SubTitle>
-        <S.Information>{description.information}</S.Information>
+        <S.Title aria-label={description.titleLabel}>
+          {description.title}
+        </S.Title>
+        <S.SubTitle aria-label={description.subTitleLabel}>
+          {description.subTitle}
+        </S.SubTitle>
+        <S.Information aria-label={description.informationLabel}>
+          {description.information}
+        </S.Information>
       </S.Description>
     </S.Container>
   );

--- a/src/components/Carousel/components/Item/index.tsx
+++ b/src/components/Carousel/components/Item/index.tsx
@@ -14,7 +14,7 @@ export interface ItemProps extends HTMLAttributes<HTMLAnchorElement> {
 const Item = ({ link, imgSrc, description, ...props }: ItemProps) => {
   return (
     <S.Container href={link} {...props}>
-      <S.Content src={imgSrc} alt={description.title} />
+      <S.Content src={imgSrc} />
       <S.Description>
         <S.Title>{description.title}</S.Title>
         <S.SubTitle>{description.subTitle}</S.SubTitle>

--- a/src/components/Carousel/components/ShiftButton/index.style.ts
+++ b/src/components/Carousel/components/ShiftButton/index.style.ts
@@ -1,12 +1,12 @@
 import styled from '@emotion/styled';
 
-export const Container = styled.button`
-  background-color: black;
+export const Container = styled.button<{ isDisable: boolean }>`
+  background-color: ${({ isDisable }) => (isDisable ? '#e8e8e8' : 'black')};
   opacity: 0.6;
   color: white;
   border: none;
   width: 30px;
   height: 60px;
   font-size: 20px;
-  cursor: pointer;
+  cursor: ${({ isDisable }) => (isDisable ? 'not-allowed' : 'pointer')}; ;
 `;

--- a/src/components/Carousel/components/ShiftButton/index.style.ts
+++ b/src/components/Carousel/components/ShiftButton/index.style.ts
@@ -1,0 +1,12 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.button`
+  background-color: black;
+  opacity: 0.6;
+  color: white;
+  border: none;
+  width: 30px;
+  height: 60px;
+  font-size: 20px;
+  cursor: pointer;
+`;

--- a/src/components/Carousel/components/ShiftButton/index.tsx
+++ b/src/components/Carousel/components/ShiftButton/index.tsx
@@ -3,10 +3,17 @@ import * as S from './index.style';
 
 interface ShiftButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   onClick: MouseEventHandler<HTMLButtonElement>;
+  isDisable: boolean;
 }
 
-const ShiftButton = ({ onClick, ...props }: ShiftButtonProps) => {
-  return <S.Container onClick={onClick} {...props}></S.Container>;
+const ShiftButton = ({ onClick, isDisable, ...props }: ShiftButtonProps) => {
+  return (
+    <S.Container
+      onClick={onClick}
+      isDisable={isDisable}
+      {...props}
+    ></S.Container>
+  );
 };
 
 export default ShiftButton;

--- a/src/components/Carousel/components/ShiftButton/index.tsx
+++ b/src/components/Carousel/components/ShiftButton/index.tsx
@@ -1,0 +1,12 @@
+import { ButtonHTMLAttributes, MouseEventHandler } from 'react';
+import * as S from './index.style';
+
+interface ShiftButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  onClick: MouseEventHandler<HTMLButtonElement>;
+}
+
+const ShiftButton = ({ onClick, ...props }: ShiftButtonProps) => {
+  return <S.Container onClick={onClick} {...props}></S.Container>;
+};
+
+export default ShiftButton;

--- a/src/components/Carousel/index.stories.tsx
+++ b/src/components/Carousel/index.stories.tsx
@@ -1,0 +1,18 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import Carousel from '.';
+import { trips } from '../../dummy';
+
+export default {
+  title: 'Components/Carousel',
+  component: Carousel,
+} as ComponentMeta<typeof Carousel>;
+
+const Template: ComponentStory<typeof Carousel> = args => (
+  <Carousel {...args} />
+);
+
+export const CarouselTemplate = Template.bind({});
+CarouselTemplate.args = {
+  title: '지금 떠나기 좋은 여행',
+  items: trips,
+};

--- a/src/components/Carousel/index.style.ts
+++ b/src/components/Carousel/index.style.ts
@@ -3,7 +3,6 @@ import ShiftButton from './components/ShiftButton';
 
 export const Container = styled.div`
   width: 100%;
-  height: 300px;
   display: flex;
   position: relative;
   flex-direction: column;
@@ -14,7 +13,7 @@ export const LeftShiftButton = styled(ShiftButton)`
   z-index: 10;
 
   left: 0;
-  top: 65%;
+  top: 50%;
   border-radius: 0 30px 30px 0;
   text-align: left;
 `;
@@ -24,7 +23,7 @@ export const RightShiftButton = styled(ShiftButton)`
   z-index: 10;
 
   right: 0;
-  top: 65%;
+  top: 50%;
   border-radius: 30px 0 0 30px;
   text-align: right;
 `;
@@ -33,13 +32,12 @@ export const Title = styled.h1`
   font-size: 20px;
 `;
 
-export const ItemContainer = styled.ul<{ shift: string }>`
-  width: fit-content;
+export const ItemContainer = styled.ul`
+  width: 100%;
+  height: 100%;
   display: flex;
   list-style: none;
   padding: 0px;
   gap: 15px;
-
-  transition: all ease 0.5s;
-  transform: ${props => `translateX(${props.shift})`};
+  overflow-x: hidden;
 `;

--- a/src/components/Carousel/index.style.ts
+++ b/src/components/Carousel/index.style.ts
@@ -1,0 +1,45 @@
+import styled from '@emotion/styled';
+import ShiftButton from './components/ShiftButton';
+
+export const Container = styled.div`
+  width: 100%;
+  height: 300px;
+  display: flex;
+  position: relative;
+  flex-direction: column;
+`;
+
+export const LeftShiftButton = styled(ShiftButton)`
+  position: absolute;
+  z-index: 10;
+
+  left: 0;
+  top: 65%;
+  border-radius: 0 30px 30px 0;
+  text-align: left;
+`;
+
+export const RightShiftButton = styled(ShiftButton)`
+  position: absolute;
+  z-index: 10;
+
+  right: 0;
+  top: 65%;
+  border-radius: 30px 0 0 30px;
+  text-align: right;
+`;
+
+export const Title = styled.h1`
+  font-size: 20px;
+`;
+
+export const ItemContainer = styled.ul<{ shift: string }>`
+  width: fit-content;
+  display: flex;
+  list-style: none;
+  padding: 0px;
+  gap: 15px;
+
+  transition: all ease 0.5s;
+  transform: ${props => `translateX(${props.shift})`};
+`;

--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, FocusEvent, useEffect, MouseEvent } from 'react';
+import { useState, useRef, FocusEvent, MouseEvent } from 'react';
 
 import Item, { ItemProps } from './components/Item';
 import * as S from './index.style';
@@ -32,23 +32,21 @@ const Carousel = ({ title, items, itemWidth = 245 }: CarouselProps) => {
     e.target.scrollIntoView({ behavior: 'smooth' });
   };
 
-  useEffect(() => {
+  const handleEnd = () => {
     if (!ItemContainer.current) return;
 
-    ItemContainer.current.addEventListener('scroll', () => {
-      const { scrollLeft, scrollWidth, offsetWidth } = ItemContainer.current!;
+    const { scrollLeft, scrollWidth, offsetWidth } = ItemContainer.current;
 
-      setEnd({
-        left: scrollLeft <= 0,
-        right: scrollWidth <= offsetWidth + scrollLeft,
-      });
+    setEnd({
+      left: scrollLeft <= 0,
+      right: scrollWidth <= offsetWidth + scrollLeft,
     });
-  }, []);
+  };
 
   return (
     <S.Container>
       <S.Title>{title}</S.Title>
-      <S.ItemContainer ref={ItemContainer}>
+      <S.ItemContainer ref={ItemContainer} onScroll={handleEnd}>
         {items &&
           items.map(item => (
             <Item

--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -1,0 +1,62 @@
+import { useState, KeyboardEvent } from 'react';
+import { Trip } from '../../dummy';
+import Item from './components/Item';
+import * as S from './index.style';
+
+interface CarouselProps {
+  title: string;
+  items?: Trip[];
+}
+
+const ITEM_WIDTH = 245;
+
+const Carousel = ({ title, items }: CarouselProps) => {
+  const [shift, setShift] = useState(0);
+
+  const LeftShift = () => {
+    setShift(shift => (shift < 0 ? shift + 245 : shift));
+  };
+
+  const RightShift = () => {
+    setShift(shift => (shift > -ITEM_WIDTH * 8 ? shift - 245 : shift));
+  };
+
+  const onPressTab = (
+    e: KeyboardEvent<HTMLUListElement> & { target: HTMLUListElement }
+  ) => {
+    const { x } = e.target.getBoundingClientRect();
+
+    if (e.shiftKey) {
+      setShift(shift => (shift < 0 ? shift + 245 : shift));
+    }
+
+    if (e.code === 'Tab' && !e.shiftKey) {
+      setShift(shift =>
+        x > window.innerWidth * 0.4 && shift > -ITEM_WIDTH * 8
+          ? shift - 245
+          : shift
+      );
+    }
+  };
+
+  return (
+    <S.Container>
+      <S.Title>{title}</S.Title>
+      <S.ItemContainer shift={shift + 'px'} onKeyUp={onPressTab}>
+        {items &&
+          items.map(item => <Item {...item} key={item.description.title} />)}
+      </S.ItemContainer>
+
+      <S.LeftShiftButton
+        onClick={LeftShift}
+        type="button"
+      >{`<`}</S.LeftShiftButton>
+      <S.RightShiftButton
+        onClick={RightShift}
+        type="button"
+      >{`>`}</S.RightShiftButton>
+    </S.Container>
+  );
+};
+
+export default Carousel;

--- a/src/components/DiscoverNow/index.style.ts
+++ b/src/components/DiscoverNow/index.style.ts
@@ -1,0 +1,8 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.div`
+  width: 100%;
+  height: 100%;
+  padding: 20px;
+  box-sizing: border-box;
+`;

--- a/src/components/DiscoverNow/index.tsx
+++ b/src/components/DiscoverNow/index.tsx
@@ -1,0 +1,13 @@
+import { trips } from '../../dummy';
+import Carousel from '../Carousel';
+import * as S from './index.style';
+
+const DiscoverNow = () => {
+  return (
+    <S.Container>
+      <Carousel title="지금 떠나기 좋은 여행" items={trips} />
+    </S.Container>
+  );
+};
+
+export default DiscoverNow;

--- a/src/dummy/index.ts
+++ b/src/dummy/index.ts
@@ -1,0 +1,92 @@
+export interface Trip {
+  link: string;
+  imgSrc: string;
+  description: {
+    title: string;
+    subTitle: string;
+    information: string;
+  };
+}
+
+export const trips: Trip[] = [
+  {
+    link: 'https://www.koreanair.com/booking/best-prices?departureCode=ICN&destinationCode=DXB&cabin=Y&tripType=RT&duration=7',
+    imgSrc:
+      'https://www.koreanair.com/content/dam/koreanair/ko/airport-img/DXB-list-pc.jpg',
+    description: {
+      title: '서울/인천 - 두바이',
+      subTitle: '일반석 왕복',
+      information: 'KRW 1,158,000 ~',
+    },
+  },
+  {
+    link: 'https://www.koreanair.com/booking/best-prices?departureCode=ICN&destinationCode=FUK&duration=7&cabin=Y',
+    imgSrc:
+      'https://www.koreanair.com/content/dam/koreanair/ko/airport-img/FUK-list-pc.jpg',
+    description: {
+      title: '서울/인천 - 후쿠오카',
+      subTitle: '일반석 왕복',
+      information: 'KRW 340,400 ~',
+    },
+  },
+  {
+    link: 'https://www.koreanair.com/booking/best-prices?departureCode=ICN&destinationCode=HKT&cabin=Y&tripType=RT&duration=7',
+    imgSrc:
+      'https://www.koreanair.com/content/dam/koreanair/ko/airport-img/HKT-list-pc.jpg',
+    description: {
+      title: '서울/인천 - 푸껫',
+      subTitle: '일반석 왕복',
+      information: 'KRW 704,100 ~',
+    },
+  },
+  {
+    link: 'https://www.koreanair.com/booking/best-prices?departureCode=ICN&destinationCode=CNX&duration=7&cabin=Y',
+    imgSrc:
+      'https://www.koreanair.com/content/dam/koreanair/ko/airport-img/CNX-list-pc.jpg',
+    description: {
+      title: '서울/인천 - 치앙마이',
+      subTitle: '일반석 왕복',
+      information: 'KRW 839,100 ~',
+    },
+  },
+  {
+    link: 'https://www.koreanair.com/booking/best-prices?departureCode=ICN&destinationCode=BCN&cabin=Y&tripType=RT&duration=7',
+    imgSrc:
+      'https://www.koreanair.com/content/dam/koreanair/ko/airport-img/BCN-list-pc.jpg',
+    description: {
+      title: '서울/인천 - 바르셀로나',
+      subTitle: '일반석 왕복',
+      information: 'KRW 1,546,300 ~',
+    },
+  },
+  {
+    link: 'https://www.koreanair.com/booking/best-prices?departureCode=ICN&destinationCode=HAN&duration=7&cabin=Y',
+    imgSrc:
+      'https://www.koreanair.com/content/dam/koreanair/ko/airport-img/HAN-list-pc.jpg',
+    description: {
+      title: '서울/인천 - 하노이',
+      subTitle: '일반석 왕복',
+      information: 'KRW 527,500 ~',
+    },
+  },
+  {
+    link: 'https://www.koreanair.com/booking/best-prices?departureCode=ICN&destinationCode=FCO&duration=7&cabin=Y',
+    imgSrc:
+      'https://www.koreanair.com/content/dam/koreanair/ko/airport-img/FCO-list-pc.jpg',
+    description: {
+      title: '서울/인천 - 로마/레오나르도 다빈치',
+      subTitle: '일반석 왕복',
+      information: 'KRW 1,454,200 ~',
+    },
+  },
+  {
+    link: 'https://www.koreanair.com/booking/best-prices?departureCode=ICN&destinationCode=HNL&cabin=Y&tripType=RT&duration=7',
+    imgSrc:
+      'https://www.koreanair.com/content/dam/koreanair/ko/airport-img/HNL-list-pc.jpg',
+    description: {
+      title: '서울/인천 - 호놀룰루 (하와이)',
+      subTitle: '일반석 왕복',
+      information: 'KRW 1,244,900 ~',
+    },
+  },
+];

--- a/src/dummy/index.ts
+++ b/src/dummy/index.ts
@@ -9,8 +9,10 @@ export const trips: Trip[] = [
       'https://www.koreanair.com/content/dam/koreanair/ko/airport-img/DXB-list-pc.jpg',
     description: {
       title: '서울/인천 - 두바이',
+      titleLabel: '서울, 인천에서 두바이',
       subTitle: '일반석 왕복',
       information: 'KRW 1,158,000 ~',
+      informationLabel: '1,158,000원부터',
     },
   },
   {
@@ -19,8 +21,10 @@ export const trips: Trip[] = [
       'https://www.koreanair.com/content/dam/koreanair/ko/airport-img/FUK-list-pc.jpg',
     description: {
       title: '서울/인천 - 후쿠오카',
+      titleLabel: '서울, 인천에서 후쿠오카',
       subTitle: '일반석 왕복',
       information: 'KRW 340,400 ~',
+      informationLabel: '340,400원부터',
     },
   },
   {
@@ -29,8 +33,10 @@ export const trips: Trip[] = [
       'https://www.koreanair.com/content/dam/koreanair/ko/airport-img/HKT-list-pc.jpg',
     description: {
       title: '서울/인천 - 푸껫',
+      titleLabel: '서울, 인천에서 푸껫',
       subTitle: '일반석 왕복',
       information: 'KRW 704,100 ~',
+      informationLabel: '704,100원부터',
     },
   },
   {
@@ -39,8 +45,10 @@ export const trips: Trip[] = [
       'https://www.koreanair.com/content/dam/koreanair/ko/airport-img/CNX-list-pc.jpg',
     description: {
       title: '서울/인천 - 치앙마이',
+      titleLabel: '서울, 인천에서 치앙마이',
       subTitle: '일반석 왕복',
       information: 'KRW 839,100 ~',
+      informationLabel: '839,100원부터',
     },
   },
   {
@@ -49,8 +57,10 @@ export const trips: Trip[] = [
       'https://www.koreanair.com/content/dam/koreanair/ko/airport-img/BCN-list-pc.jpg',
     description: {
       title: '서울/인천 - 바르셀로나',
+      titleLabel: '서울, 인천에서 바르셀로나',
       subTitle: '일반석 왕복',
       information: 'KRW 1,546,300 ~',
+      informationLabel: '1,546,300원부터',
     },
   },
   {
@@ -59,8 +69,10 @@ export const trips: Trip[] = [
       'https://www.koreanair.com/content/dam/koreanair/ko/airport-img/HAN-list-pc.jpg',
     description: {
       title: '서울/인천 - 하노이',
+      titleLabel: '서울, 인천에서 하노이',
       subTitle: '일반석 왕복',
       information: 'KRW 527,500 ~',
+      informationLabel: '527,500원부터',
     },
   },
   {
@@ -69,8 +81,10 @@ export const trips: Trip[] = [
       'https://www.koreanair.com/content/dam/koreanair/ko/airport-img/FCO-list-pc.jpg',
     description: {
       title: '서울/인천 - 로마/레오나르도 다빈치',
+      titleLabel: '서울, 인천에서 로마, 레오나르도 다빈치',
       subTitle: '일반석 왕복',
       information: 'KRW 1,454,200 ~',
+      informationLabel: '1,454,200원부터',
     },
   },
   {
@@ -79,8 +93,10 @@ export const trips: Trip[] = [
       'https://www.koreanair.com/content/dam/koreanair/ko/airport-img/HNL-list-pc.jpg',
     description: {
       title: '서울/인천 - 호놀룰루 (하와이)',
+      titleLabel: '서울, 인천에서 하와이, 호놀룰루',
       subTitle: '일반석 왕복',
       information: 'KRW 1,244,900 ~',
+      informationLabel: '1,244,900원부터',
     },
   },
 ];

--- a/src/dummy/index.ts
+++ b/src/dummy/index.ts
@@ -1,12 +1,6 @@
-export interface Trip {
-  link: string;
-  imgSrc: string;
-  description: {
-    title: string;
-    subTitle: string;
-    information: string;
-  };
-}
+import { ItemProps } from '../components/Carousel/components/Item';
+
+export interface Trip extends ItemProps {}
 
 export const trips: Trip[] = [
   {


### PR DESCRIPTION
안녕하세요 도리 !!!!!!!!!! 🐠
다시 만나서 너무 반갑네요 !!!!! >_< ❤️👏

저번 미션에서 헐레벌떡 merge 돼서 너무 ㅠㅠ 슬프고 아쉬웠는데.. step2에도 만나니.. 이르케..행복할 수가 (크흡)
 
<img width="135" alt="스크린샷_2022-10-13_오전_12 26 42-removebg-preview" src="https://user-images.githubusercontent.com/52737532/195384681-11d4a16b-c213-45bc-97d1-1e277a60cda0.png">

(이제 기간을 잘 살펴봐야겠어오..)

지난번 미션에서.. 다른 환경 테스트를 전혀 안했더니.. 엉망이었던 과거를 청산하고자,
맥북 보이스오버(크롬), 안드로이드 톡백(삼성 인터넷), IOS 보이스오버(사파리) 세가지 환경에서 테스트를 진행했습니다..! (이젠 진짜 됐..나..?)

아무튼 이번 미션도 잘 부탁드립니다 !!! 🥺👍


## 🔥 결과

직접 구현한 페이지를 작동시켜볼 수 있도록 접근 가능한 페이지 링크를 공유해주세요.

### [🛫 무비의 Airline](https://byhhh2.github.io/a11y-airline/)

## ✅ 요구사항 목록

**2 Carousel**

- [x] 총 8개의 carousel 중 2개의 목록을 기본으로 보여준다.
- [x] 실제 스크린 리더는 아래와 같이 읽을 수 있어야 합니다. 단, 스크린 리더기 마다 읽는 방법이 다를 수 있으니 참고만 해주세요. 중요한건 스크린 리더기를 활용하여 동작을 할 수 있어야 합니다.
- [x] 리팩터링 과정에서 불필요하거나 웹 표준에 어긋나는 마크업은 없는지 확인합니다.

```
1. 지금 떠나기 좋은 여행
2. 목록 8개 항목 포함 서울/인천 로스앤젤레스 일반석 왕복 1,481,800 대한민국 원 링크 목록 항목
3. 다음 버튼 (사용 중지)
4. 이전 버튼 (사용 중지)
```

## 🧐 공유

### 🛫 carousel.. 도대체 어떻게 구현해야할까?

우선 저는 3가지 방법을 고민했는데요!
**가장 먼저 시도한 방법**은 `대한항공`이 쓴 방법이였습니다.!

`대한항공`에서는 

<img width="230" alt="스크린샷 2022-10-13 오전 12 33 04" src="https://user-images.githubusercontent.com/52737532/195385900-502039ce-e306-40d6-b52f-6cfe593d212a.png">

translate를 통해 캐러셀을 움직여주더라구요...!
translate + onkeypress를 통해 구현해주려고 했는데.. 
전 바보 🥲였던 거죠.. `onkeypress`를.. 모바일에서 쓰기엔 까다롭다는 것..
그래서 3시간정도 투자했었는데 (계산 열심히함) 갈아 엎었습니다. 킥..키킥..

<img width="428" alt="스크린샷 2022-10-13 오전 12 35 42" src="https://user-images.githubusercontent.com/52737532/195386490-cb20acba-71ff-4e0e-918d-d3da2046a1d2.png">

(~~무비의 눈물의 DM..~~)

**두번째 방법은** !! Item에 ref를 걸고 index로 처리해보자! 였습니다. (ref index + onFocus)
이 방법은..또 갈아엎어졌는데,,
이유는 .. 왼쪽끝과 오른쪽끝 계산이 또 복잡해지더라구요.. 쩝.. 더 시도해보고 싶었지만,, 시간의 한계로 포기했습니다. 

**세번째 방법**은 블링에게 힌트를 얻었는데요!
저는 `scrollIntoView`, `scrollBy` 등 스크롤 관련 메서드들이 `overflow: scroll`에서만 적용이 되는 줄 알았는데 
`overflow: hidden`으로 설정해줘도 먹더라구요! 캬~
그래서 사용자에게서는 스크롤을 막아두고 JS로만 스크롤을 조작할 수 있어서 마치 translate!로 조작한 것 마냥 구현해줄 수 있었습니다 ㅎㅎ

### 🛫 접근성 관련해서는 머리 굴릴 부분이 없었어요!!

우선 저는 `대한항공` 페이지 먼저 참고해서 그런가
바로 `<ul>`, `<li>`, `<a>` 태그를 사용했습니다. 
와 근데 `<ul>`, `<li>`, `<a>`가 접근성 최고더라구요..
아주 굿.. 👍 

> 대부분의 WAI-ARIA 명세는 HTML 요소와 속성을 흉내내는 것입니다. 올바른 HTML을 사용한다면 WAI-ARIA 사용을 최소화할 수 있습니다. WAI-ARIA를 사용하기에 앞서 HTML을 의미 있게 사용했는지 충분히 검토합니다. - [레진](https://github.com/lezhin/accessibility/tree/master/aria)

이걸 이제 이해할지도..?! 

또, 버튼 비활성화 관련해서는 돔하디에게 힌트를 얻었는데요 ㅎㅎ.
`aria-disabled`를 사용하면 버튼이 disable됐다고 스크린리더가 읽어주고, focus가 가능하더라구요!! (disabled는 focus가 안됐던 것 같아효) 너무 굿...


> 아무튼 도리 !!! 미리 감사합니다 🙂 오늘도 내일도 화이팅!
