### PR TITLE
[항공사 웹사이트의 컴포넌트 접근성 높이기 - 2단계] 나인(장호영) 미션 제출합니다.

### DIFF
--- a/src/App.styles.ts
+++ b/src/App.styles.ts
@@ -5,10 +5,7 @@ const layoutStyle = css`
   flex-direction: column;
   gap: 10px;
 
-  width: 120px;
-  padding: 20px;
-  border: 1px solid #ced4da;
-  border-radius: 8px;
+  margin: 10px;
 `;
 
 export { layoutStyle };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource @emotion/react */
 
 import { layoutStyle } from './App.styles';
+import Carousel from './Carousel/Carousel';
 import { PASSENGER_TYPE } from './constants';
 import HelpTooltip from './HelpTooltip/HelpTooltip';
 import SpinButton from './SpinButton/SpinButton';
@@ -15,6 +16,8 @@ function App() {
         tooltipMessage="성인은 만 18세 이상 탑승자로 최대 3명까지 추가할 수 있어요."
       />
       <SpinButton min={0} max={3} passengerType={PASSENGER_TYPE.ADULT} />
+
+      <Carousel />
     </div>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ function App() {
       />
       <SpinButton min={0} max={3} passengerType={PASSENGER_TYPE.ADULT} />
 
+      <h2>지금 떠나기 좋은 여행</h2>
       <Carousel />
     </div>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,7 @@ function App() {
       />
       <SpinButton min={0} max={3} passengerType={PASSENGER_TYPE.ADULT} />
 
-      <h2>지금 떠나기 좋은 여행</h2>
+      <h2 tabIndex={0}>지금 떠나기 좋은 여행</h2>
       <Carousel />
     </div>
   );

--- a/src/Carousel/Carousel.styles.ts
+++ b/src/Carousel/Carousel.styles.ts
@@ -54,15 +54,4 @@ const nextButtonStyle = css`
   }
 `;
 
-const hiddenStyle = css`
-  overflow: hidden;
-  white-space: nowrap;
-  clip: rect(1px, 1px, 1px, 1px);
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  margin: 0;
-  padding: 0;
-  border: 0;
-`;
-export { layoutStyle, listStyle, prevButtonStyle, nextButtonStyle, hiddenStyle };
+export { layoutStyle, listStyle, prevButtonStyle, nextButtonStyle };

--- a/src/Carousel/Carousel.styles.ts
+++ b/src/Carousel/Carousel.styles.ts
@@ -12,9 +12,8 @@ const layoutStyle = (length: number) => css`
 const listStyle = css`
   display: flex;
   gap: 30px;
-
-  height: 310px;
-  overflow: overlay;
+  overflow: hidden;
+  padding: 0;
 `;
 
 const prevButtonStyle = css`

--- a/src/Carousel/Carousel.styles.ts
+++ b/src/Carousel/Carousel.styles.ts
@@ -29,6 +29,9 @@ const prevButtonStyle = css`
   border: none;
 
   box-sizing: border-box;
+
+  font-size: 0;
+
   &:hover {
     border: 1px solid blue;
     cursor: pointer;
@@ -47,6 +50,8 @@ const nextButtonStyle = css`
   width: 32px;
   height: 60px;
   border: none;
+
+  font-size: 0;
 
   &:hover {
     border: 1px solid blue;

--- a/src/Carousel/Carousel.styles.ts
+++ b/src/Carousel/Carousel.styles.ts
@@ -1,0 +1,69 @@
+import { css } from '@emotion/react';
+
+const layoutStyle = css`
+  position: relative;
+  display: flex;
+
+  overflow: overlay;
+`;
+
+const listStyle = css`
+  position: relative;
+  display: flex;
+  flex=direction: row;
+  gap: 30px;
+
+  height: 310px;
+  overflow: overlay;
+`;
+
+const prevButtonStyle = css`
+  position: sticky;
+  top: 50%;
+  left: 30px;
+  z-index: 10;
+  background: url(https://www.koreanair.com/etc.clientlibs/koreanair/clientlibs/clientlib-base/resources/images/mris__button-left.svg)
+    no-repeat;
+  transform: translate(0, -50%);
+
+  width: 40px;
+  height: 60px;
+  border: none;
+
+  &:hover {
+    border: 1px solid blue;
+    cursor: pointer;
+  }
+`;
+
+const nextButtonStyle = css`
+  position: sticky;
+  top: 50%;
+  right: 30px;
+  z-index: 10;
+  background: url(https://www.koreanair.com/etc.clientlibs/koreanair/clientlibs/clientlib-base/resources/images/mris__button-right.svg)
+    no-repeat;
+  transform: translate(0, -50%);
+
+  width: 40px;
+  height: 60px;
+  border: none;
+
+  &:hover {
+    border: 1px solid blue;
+    cursor: pointer;
+  }
+`;
+
+const hiddenStyle = css`
+  overflow: hidden;
+  white-space: nowrap;
+  clip: rect(1px, 1px, 1px, 1px);
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: 0;
+  padding: 0;
+  border: 0;
+`;
+export { layoutStyle, listStyle, prevButtonStyle, nextButtonStyle, hiddenStyle };

--- a/src/Carousel/Carousel.styles.ts
+++ b/src/Carousel/Carousel.styles.ts
@@ -40,7 +40,7 @@ const nextButtonStyle = css`
   top: 50%;
   right: 0;
   z-index: 10;
-  background: url(https://www.koreanair.com/etc.clientlibs/koreanair/clientlibs/clientlib-base/resources/images/mris__button-left.svg)
+  background: url(https://www.koreanair.com/etc.clientlibs/koreanair/clientlibs/clientlib-base/resources/images/mris__button-right.svg)
     no-repeat;
   transform: translate(0, -50%);
 

--- a/src/Carousel/Carousel.styles.ts
+++ b/src/Carousel/Carousel.styles.ts
@@ -1,16 +1,16 @@
 import { css } from '@emotion/react';
 
-const layoutStyle = css`
+const layoutStyle = (length: number) => css`
   position: relative;
   display: flex;
 
   overflow: overlay;
+  width: ${length * 329}px;
+  max-width: 100%;
 `;
 
 const listStyle = css`
-  position: relative;
   display: flex;
-  flex=direction: row;
   gap: 30px;
 
   height: 310px;
@@ -18,18 +18,18 @@ const listStyle = css`
 `;
 
 const prevButtonStyle = css`
-  position: sticky;
+  position: absolute;
   top: 50%;
-  left: 30px;
   z-index: 10;
   background: url(https://www.koreanair.com/etc.clientlibs/koreanair/clientlibs/clientlib-base/resources/images/mris__button-left.svg)
     no-repeat;
   transform: translate(0, -50%);
 
-  width: 40px;
+  width: 32px;
   height: 60px;
   border: none;
 
+  box-sizing: border-box;
   &:hover {
     border: 1px solid blue;
     cursor: pointer;
@@ -37,15 +37,15 @@ const prevButtonStyle = css`
 `;
 
 const nextButtonStyle = css`
-  position: sticky;
+  position: absolute;
   top: 50%;
-  right: 30px;
+  right: 0;
   z-index: 10;
-  background: url(https://www.koreanair.com/etc.clientlibs/koreanair/clientlibs/clientlib-base/resources/images/mris__button-right.svg)
+  background: url(https://www.koreanair.com/etc.clientlibs/koreanair/clientlibs/clientlib-base/resources/images/mris__button-left.svg)
     no-repeat;
   transform: translate(0, -50%);
 
-  width: 40px;
+  width: 32px;
   height: 60px;
   border: none;
 

--- a/src/Carousel/Carousel.tsx
+++ b/src/Carousel/Carousel.tsx
@@ -12,7 +12,7 @@ import {
 
 function Carousel() {
   return (
-    <div css={layoutStyle}>
+    <div css={layoutStyle(data.length)}>
       <button css={prevButtonStyle}>
         <span css={hiddenStyle}>이전</span>
       </button>

--- a/src/Carousel/Carousel.tsx
+++ b/src/Carousel/Carousel.tsx
@@ -49,10 +49,8 @@ function Carousel() {
         css={prevButtonStyle}
         onClick={handleClickPrevButton}
         aria-disabled={isStart}
-        disabled={isStart}
-      >
-        <span css={hiddenStyle}>이전</span>
-      </button>
+        aria-hidden
+      ></button>
       <ul css={listStyle} ref={listRef}>
         {data.map((el) => (
           <TravelInfo
@@ -69,10 +67,8 @@ function Carousel() {
         css={nextButtonStyle}
         onClick={handleClickNextButton}
         aria-disabled={isEnd}
-        disabled={isEnd}
-      >
-        <span css={hiddenStyle}>다음</span>
-      </button>
+        aria-hidden
+      ></button>
     </div>
   );
 }

--- a/src/Carousel/Carousel.tsx
+++ b/src/Carousel/Carousel.tsx
@@ -39,6 +39,16 @@ function Carousel() {
   return (
     <div css={layoutStyle(data.length)}>
       <ul css={listStyle} ref={listRef}>
+        <button css={prevButtonStyle} onClick={handleClickPrevButton} aria-disabled={isStart}>
+          이전
+        </button>
+        <button
+          css={nextButtonStyle}
+          onClick={handleClickNextButton}
+          aria-disabled={isEnd || false}
+        >
+          다음
+        </button>
         {data.map((el) => (
           <TravelInfo
             key={el.id}
@@ -50,12 +60,6 @@ function Carousel() {
           />
         ))}
       </ul>
-      <button css={prevButtonStyle} onClick={handleClickPrevButton} aria-disabled={isStart}>
-        이전
-      </button>
-      <button css={nextButtonStyle} onClick={handleClickNextButton} aria-disabled={isEnd || false}>
-        다음
-      </button>
     </div>
   );
 }

--- a/src/Carousel/Carousel.tsx
+++ b/src/Carousel/Carousel.tsx
@@ -17,8 +17,7 @@ function Carousel() {
 
   const isStart = page < 1;
   const isEnd =
-    listRef.current === null ||
-    (listRef.current && page * 264 >= listRef.current.scrollWidth - listRef.current.offsetWidth);
+    listRef.current && page * 264 >= listRef.current.scrollWidth - listRef.current.offsetWidth;
 
   const handleClickPrevButton = () => {
     if (isStart) {
@@ -48,8 +47,8 @@ function Carousel() {
       <button
         css={prevButtonStyle}
         onClick={handleClickPrevButton}
-        aria-disabled={isStart}
-        aria-hidden
+        aria-hidden={true}
+        tabIndex={-1}
       ></button>
       <ul css={listStyle} ref={listRef}>
         {data.map((el) => (
@@ -66,8 +65,8 @@ function Carousel() {
       <button
         css={nextButtonStyle}
         onClick={handleClickNextButton}
-        aria-disabled={isEnd}
-        aria-hidden
+        aria-hidden={true}
+        tabIndex={-1}
       ></button>
     </div>
   );

--- a/src/Carousel/Carousel.tsx
+++ b/src/Carousel/Carousel.tsx
@@ -17,7 +17,8 @@ function Carousel() {
 
   const isStart = page < 1;
   const isEnd =
-    listRef.current && page * 264 >= listRef.current.scrollWidth - listRef.current.offsetWidth;
+    listRef.current === null ||
+    (listRef.current && page * 264 >= listRef.current.scrollWidth - listRef.current.offsetWidth);
 
   const handleClickPrevButton = () => {
     if (isStart) {
@@ -44,7 +45,12 @@ function Carousel() {
 
   return (
     <div css={layoutStyle(data.length)}>
-      <button css={prevButtonStyle} onClick={handleClickPrevButton}>
+      <button
+        css={prevButtonStyle}
+        onClick={handleClickPrevButton}
+        aria-disabled={isStart}
+        disabled={isStart}
+      >
         <span css={hiddenStyle}>이전</span>
       </button>
       <ul css={listStyle} ref={listRef}>
@@ -59,7 +65,12 @@ function Carousel() {
           />
         ))}
       </ul>
-      <button css={nextButtonStyle} onClick={handleClickNextButton}>
+      <button
+        css={nextButtonStyle}
+        onClick={handleClickNextButton}
+        aria-disabled={isEnd}
+        disabled={isEnd}
+      >
         <span css={hiddenStyle}>다음</span>
       </button>
     </div>

--- a/src/Carousel/Carousel.tsx
+++ b/src/Carousel/Carousel.tsx
@@ -3,13 +3,7 @@
 import { useRef, useState } from 'react';
 import { data } from '../data';
 import TravelInfo from '../TravelInfo/TravelInfo';
-import {
-  hiddenStyle,
-  layoutStyle,
-  listStyle,
-  nextButtonStyle,
-  prevButtonStyle,
-} from './Carousel.styles';
+import { layoutStyle, listStyle, nextButtonStyle, prevButtonStyle } from './Carousel.styles';
 
 function Carousel() {
   const [page, setPage] = useState(0);

--- a/src/Carousel/Carousel.tsx
+++ b/src/Carousel/Carousel.tsx
@@ -1,0 +1,37 @@
+/** @jsxImportSource @emotion/react */
+
+import { data } from '../data';
+import TravelInfo from '../TravelInfo/TravelInfo';
+import {
+  hiddenStyle,
+  layoutStyle,
+  listStyle,
+  nextButtonStyle,
+  prevButtonStyle,
+} from './Carousel.styles';
+
+function Carousel() {
+  return (
+    <div css={layoutStyle}>
+      <button css={prevButtonStyle}>
+        <span css={hiddenStyle}>이전</span>
+      </button>
+      <li css={listStyle}>
+        {data.map((el) => (
+          <TravelInfo
+            key={el.id}
+            location={el.location}
+            seat={el.seat}
+            price={el.price}
+            image={el.image}
+            href={el.href}
+          />
+        ))}
+      </li>
+      <button css={nextButtonStyle}>
+        <span css={hiddenStyle}>다음</span>
+      </button>
+    </div>
+  );
+}
+export default Carousel;

--- a/src/Carousel/Carousel.tsx
+++ b/src/Carousel/Carousel.tsx
@@ -38,12 +38,6 @@ function Carousel() {
 
   return (
     <div css={layoutStyle(data.length)}>
-      <button
-        css={prevButtonStyle}
-        onClick={handleClickPrevButton}
-        aria-hidden={true}
-        tabIndex={-1}
-      ></button>
       <ul css={listStyle} ref={listRef}>
         {data.map((el) => (
           <TravelInfo
@@ -56,12 +50,12 @@ function Carousel() {
           />
         ))}
       </ul>
-      <button
-        css={nextButtonStyle}
-        onClick={handleClickNextButton}
-        aria-hidden={true}
-        tabIndex={-1}
-      ></button>
+      <button css={prevButtonStyle} onClick={handleClickPrevButton} aria-disabled={isStart}>
+        이전
+      </button>
+      <button css={nextButtonStyle} onClick={handleClickNextButton} aria-disabled={isEnd || false}>
+        다음
+      </button>
     </div>
   );
 }

--- a/src/Carousel/Carousel.tsx
+++ b/src/Carousel/Carousel.tsx
@@ -1,5 +1,6 @@
 /** @jsxImportSource @emotion/react */
 
+import { useRef, useState } from 'react';
 import { data } from '../data';
 import TravelInfo from '../TravelInfo/TravelInfo';
 import {
@@ -11,12 +12,42 @@ import {
 } from './Carousel.styles';
 
 function Carousel() {
+  const [page, setPage] = useState(0);
+  const listRef = useRef<HTMLUListElement>(null);
+
+  const isStart = page < 1;
+  const isEnd =
+    listRef.current && page * 264 >= listRef.current.scrollWidth - listRef.current.offsetWidth;
+
+  const handleClickPrevButton = () => {
+    if (isStart) {
+      return;
+    }
+
+    setPage((prev) => {
+      const cur = prev - 1;
+      listRef.current?.scrollTo({ top: 0, left: 264 * cur, behavior: 'smooth' });
+
+      return cur;
+    });
+  };
+  const handleClickNextButton = () => {
+    if (isEnd) return;
+
+    setPage((prev) => {
+      const cur = prev + 1;
+      listRef.current?.scrollTo({ top: 0, left: 264 * cur, behavior: 'smooth' });
+
+      return cur;
+    });
+  };
+
   return (
     <div css={layoutStyle(data.length)}>
-      <button css={prevButtonStyle}>
+      <button css={prevButtonStyle} onClick={handleClickPrevButton}>
         <span css={hiddenStyle}>이전</span>
       </button>
-      <li css={listStyle}>
+      <ul css={listStyle} ref={listRef}>
         {data.map((el) => (
           <TravelInfo
             key={el.id}
@@ -27,8 +58,8 @@ function Carousel() {
             href={el.href}
           />
         ))}
-      </li>
-      <button css={nextButtonStyle}>
+      </ul>
+      <button css={nextButtonStyle} onClick={handleClickNextButton}>
         <span css={hiddenStyle}>다음</span>
       </button>
     </div>

--- a/src/TravelInfo/TravelInfo.styles.ts
+++ b/src/TravelInfo/TravelInfo.styles.ts
@@ -4,6 +4,7 @@ const layoutStyle = css`
   position: relative;
   width: 236px;
   height: 299px;
+  list-style-type: none;
 `;
 
 const linkStyle = css`

--- a/src/TravelInfo/TravelInfo.styles.ts
+++ b/src/TravelInfo/TravelInfo.styles.ts
@@ -1,0 +1,39 @@
+import { css } from '@emotion/react';
+
+const layoutStyle = css`
+  position: relative;
+  width: 236px;
+  height: 299px;
+`;
+
+const linkStyle = css`
+  text-decoration: none;
+  color: black;
+`;
+
+const imageStyle = css`
+  width: 234px;
+  height: 299px;
+`;
+
+const textStyle = css`
+  position: absolute;
+  top: 10%;
+  padding-left: 20px;
+`;
+
+const locationStyle = css`
+  font-size: 14px;
+  font-weight: bold;
+  margin: 0 0 8px;
+`;
+
+const seatStyle = css`
+  font-size: 12px;
+`;
+
+const priceStyle = css`
+  font-size: 14px;
+`;
+
+export { layoutStyle, imageStyle, textStyle, locationStyle, seatStyle, priceStyle, linkStyle };

--- a/src/TravelInfo/TravelInfo.styles.ts
+++ b/src/TravelInfo/TravelInfo.styles.ts
@@ -35,6 +35,8 @@ const seatStyle = css`
 
 const priceStyle = css`
   font-size: 15px;
+  color: navy;
+  font-weight: bold;
 `;
 
 export { layoutStyle, imageStyle, textStyle, locationStyle, seatStyle, priceStyle, linkStyle };

--- a/src/TravelInfo/TravelInfo.styles.ts
+++ b/src/TravelInfo/TravelInfo.styles.ts
@@ -34,7 +34,7 @@ const seatStyle = css`
 `;
 
 const priceStyle = css`
-  font-size: 14px;
+  font-size: 15px;
 `;
 
 export { layoutStyle, imageStyle, textStyle, locationStyle, seatStyle, priceStyle, linkStyle };

--- a/src/TravelInfo/TravelInfo.tsx
+++ b/src/TravelInfo/TravelInfo.tsx
@@ -21,14 +21,16 @@ interface TravelInfoProps {
 function TravelInfo({ location, seat, price, image, href }: TravelInfoProps) {
   return (
     <li css={layoutStyle}>
-      <a href={href} css={linkStyle}>
-        <img src={image} alt={location} css={imageStyle} aria-hidden />
+      <a
+        href={href}
+        css={linkStyle}
+        aria-label={`${location} ${seat} 최저가 ${price.toLocaleString('ko-kr')} 대한민국 원부터`}
+      >
+        <img src={image} alt={location} css={imageStyle} />
         <div css={textStyle}>
           <p css={locationStyle}>{location}</p>
           <p css={seatStyle}>{seat}</p>
-          <p css={priceStyle}>
-            KRW {price.toLocaleString('ko-kr')} <span aria-hidden>~</span>
-          </p>
+          <p css={priceStyle}>KRW {price.toLocaleString('ko-kr')} ~</p>
         </div>
       </a>
     </li>

--- a/src/TravelInfo/TravelInfo.tsx
+++ b/src/TravelInfo/TravelInfo.tsx
@@ -1,0 +1,39 @@
+/** @jsxImportSource @emotion/react */
+
+import {
+  imageStyle,
+  layoutStyle,
+  linkStyle,
+  locationStyle,
+  priceStyle,
+  seatStyle,
+  textStyle,
+} from './TravelInfo.styles';
+
+interface TravelInfoProps {
+  location: string;
+  seat: string;
+  price: number;
+  image: string;
+  href: string;
+}
+
+function TravelInfo({ location, seat, price, image, href }: TravelInfoProps) {
+  return (
+    <li css={layoutStyle}>
+      <a href={href} css={linkStyle}>
+        <div>
+          <img src={image} alt={location} css={imageStyle} />
+        </div>
+        <div css={textStyle}>
+          <p css={locationStyle}>{location}</p>
+          <p css={seatStyle}>{seat}</p>
+          <p css={priceStyle}>
+            KRW {price} <span aria-hidden>~</span>
+          </p>
+        </div>
+      </a>
+    </li>
+  );
+}
+export default TravelInfo;

--- a/src/TravelInfo/TravelInfo.tsx
+++ b/src/TravelInfo/TravelInfo.tsx
@@ -22,7 +22,7 @@ function TravelInfo({ location, seat, price, image, href }: TravelInfoProps) {
   return (
     <li css={layoutStyle}>
       <a href={href} css={linkStyle}>
-        <img src={image} alt={location} css={imageStyle} />
+        <img src={image} alt={location} css={imageStyle} aria-hidden />
         <div css={textStyle}>
           <p css={locationStyle}>{location}</p>
           <p css={seatStyle}>{seat}</p>

--- a/src/TravelInfo/TravelInfo.tsx
+++ b/src/TravelInfo/TravelInfo.tsx
@@ -26,8 +26,8 @@ function TravelInfo({ location, seat, price, image, href }: TravelInfoProps) {
         css={linkStyle}
         aria-label={`${location} ${seat} 최저가 ${price.toLocaleString('ko-kr')} 대한민국 원부터`}
       >
-        <img src={image} alt={location} css={imageStyle} />
-        <div css={textStyle}>
+        <img src={image} alt={location} css={imageStyle} aria-hidden />
+        <div css={textStyle} aria-hidden>
           <p css={locationStyle}>{location}</p>
           <p css={seatStyle}>{seat}</p>
           <p css={priceStyle}>KRW {price.toLocaleString('ko-kr')} ~</p>

--- a/src/TravelInfo/TravelInfo.tsx
+++ b/src/TravelInfo/TravelInfo.tsx
@@ -22,9 +22,7 @@ function TravelInfo({ location, seat, price, image, href }: TravelInfoProps) {
   return (
     <li css={layoutStyle}>
       <a href={href} css={linkStyle}>
-        <div>
-          <img src={image} alt={location} css={imageStyle} />
-        </div>
+        <img src={image} alt={location} css={imageStyle} />
         <div css={textStyle}>
           <p css={locationStyle}>{location}</p>
           <p css={seatStyle}>{seat}</p>

--- a/src/TravelInfo/TravelInfo.tsx
+++ b/src/TravelInfo/TravelInfo.tsx
@@ -27,7 +27,7 @@ function TravelInfo({ location, seat, price, image, href }: TravelInfoProps) {
           <p css={locationStyle}>{location}</p>
           <p css={seatStyle}>{seat}</p>
           <p css={priceStyle}>
-            KRW {price} <span aria-hidden>~</span>
+            KRW {price.toLocaleString('ko-kr')} <span aria-hidden>~</span>
           </p>
         </div>
       </a>

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -4,8 +4,7 @@ export const data = [
     location: '서울/인천 - 두바이',
     seat: '일반석 왕복',
     price: 1158000,
-    image:
-      'https://wttc.org/DesktopModules/MVC/NewsArticleList/images/141_20201013185512_Consumer%20Survey%20Finds%2070%20Percent%20of%20Travelers%20Plan%20to%20Holiday%20in%202021.jpg',
+    image: 'https://www.koreanair.com/content/dam/koreanair/ko/airport-img/DXB-list-pc.jpg',
     href: 'https://www.koreanair.com/booking/best-prices?departureCode=ICN&destinationCode=DXB&duration=7&cabin=Y',
   },
   {
@@ -13,8 +12,7 @@ export const data = [
     location: '서울/인천 - 후쿠오카',
     seat: '일반석 왕복',
     price: 340400,
-    image:
-      'https://wttc.org/DesktopModules/MVC/NewsArticleList/images/141_20201013185512_Consumer%20Survey%20Finds%2070%20Percent%20of%20Travelers%20Plan%20to%20Holiday%20in%202021.jpg',
+    image: 'https://www.koreanair.com/content/dam/koreanair/ko/airport-img/FUK-list-pc.jpg',
     href: 'https://www.koreanair.com/booking/best-prices?departureCode=ICN&destinationCode=FUK&duration=7&cabin=Y',
   },
   {
@@ -22,8 +20,7 @@ export const data = [
     location: '서울/인천 - 푸껫',
     seat: '일반석 왕복',
     price: 704200,
-    image:
-      'https://wttc.org/DesktopModules/MVC/NewsArticleList/images/141_20201013185512_Consumer%20Survey%20Finds%2070%20Percent%20of%20Travelers%20Plan%20to%20Holiday%20in%202021.jpg',
+    image: 'https://www.koreanair.com/content/dam/koreanair/ko/airport-img/HKT-list-pc.jpg',
     href: 'https://www.koreanair.com/booking/best-prices?departureCode=ICN&destinationCode=HKT&cabin=Y&tripType=RT&duration=7',
   },
   {
@@ -31,8 +28,7 @@ export const data = [
     location: '서울/인천 - 치앙마이',
     seat: '일반석 왕복',
     price: 839200,
-    image:
-      'https://wttc.org/DesktopModules/MVC/NewsArticleList/images/141_20201013185512_Consumer%20Survey%20Finds%2070%20Percent%20of%20Travelers%20Plan%20to%20Holiday%20in%202021.jpg',
+    image: 'https://www.koreanair.com/content/dam/koreanair/ko/airport-img/CNX-list-pc.jpg',
     href: 'https://www.koreanair.com/booking/best-prices?departureCode=ICN&destinationCode=CNX&cabin=Y&tripType=RT&duration=7',
   },
   {
@@ -40,8 +36,7 @@ export const data = [
     location: '서울/인천 - 바르셀로나',
     seat: '일반석 왕복',
     price: 1546300,
-    image:
-      'https://wttc.org/DesktopModules/MVC/NewsArticleList/images/141_20201013185512_Consumer%20Survey%20Finds%2070%20Percent%20of%20Travelers%20Plan%20to%20Holiday%20in%202021.jpg',
+    image: 'https://www.koreanair.com/content/dam/koreanair/ko/airport-img/BCN-list-pc.jpg',
     href: 'https://www.koreanair.com/booking/best-prices?departureCode=ICN&destinationCode=BCN&cabin=Y&tripType=RT&duration=7',
   },
   {
@@ -49,8 +44,7 @@ export const data = [
     location: '서울/인천 - 하노이',
     seat: '일반석 왕복',
     price: 527400,
-    image:
-      'https://wttc.org/DesktopModules/MVC/NewsArticleList/images/141_20201013185512_Consumer%20Survey%20Finds%2070%20Percent%20of%20Travelers%20Plan%20to%20Holiday%20in%202021.jpg',
+    image: 'https://www.koreanair.com/content/dam/koreanair/ko/airport-img/HAN-list-pc.jpg',
     href: 'https://www.koreanair.com/booking/best-prices?departureCode=ICN&destinationCode=HAN&cabin=Y&tripType=RT&duration=7',
   },
   {
@@ -58,8 +52,7 @@ export const data = [
     location: '서울/인천 - 로마/레오나르도 다빈치',
     seat: '일반석 왕복',
     price: 1454300,
-    image:
-      'https://wttc.org/DesktopModules/MVC/NewsArticleList/images/141_20201013185512_Consumer%20Survey%20Finds%2070%20Percent%20of%20Travelers%20Plan%20to%20Holiday%20in%202021.jpg',
+    image: 'https://www.koreanair.com/content/dam/koreanair/ko/airport-img/FCO-list-pc.jpg',
     href: 'https://www.koreanair.com/booking/best-prices?departureCode=ICN&destinationCode=HNL&cabin=Y&tripType=RT&duration=7',
   },
   {
@@ -67,8 +60,7 @@ export const data = [
     location: '서울/인천 - 호놀룰루(하와이)',
     seat: '일반석 왕복',
     price: 1244900,
-    image:
-      'https://wttc.org/DesktopModules/MVC/NewsArticleList/images/141_20201013185512_Consumer%20Survey%20Finds%2070%20Percent%20of%20Travelers%20Plan%20to%20Holiday%20in%202021.jpg',
+    image: 'https://www.koreanair.com/content/dam/koreanair/ko/airport-img/HNL-list-pc.jpg',
     href: 'https://www.koreanair.com/booking/best-prices?departureCode=ICN&destinationCode=HNL&cabin=Y&tripType=RT&duration=7',
   },
 ];

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -1,0 +1,74 @@
+export const data = [
+  {
+    id: 0,
+    location: '서울/인천 - 두바이',
+    seat: '일반석 왕복',
+    price: 1158000,
+    image:
+      'https://wttc.org/DesktopModules/MVC/NewsArticleList/images/141_20201013185512_Consumer%20Survey%20Finds%2070%20Percent%20of%20Travelers%20Plan%20to%20Holiday%20in%202021.jpg',
+    href: 'https://www.koreanair.com/booking/best-prices?departureCode=ICN&destinationCode=DXB&duration=7&cabin=Y',
+  },
+  {
+    id: 1,
+    location: '서울/인천 - 후쿠오카',
+    seat: '일반석 왕복',
+    price: 340400,
+    image:
+      'https://wttc.org/DesktopModules/MVC/NewsArticleList/images/141_20201013185512_Consumer%20Survey%20Finds%2070%20Percent%20of%20Travelers%20Plan%20to%20Holiday%20in%202021.jpg',
+    href: 'https://www.koreanair.com/booking/best-prices?departureCode=ICN&destinationCode=FUK&duration=7&cabin=Y',
+  },
+  {
+    id: 2,
+    location: '서울/인천 - 푸껫',
+    seat: '일반석 왕복',
+    price: 704200,
+    image:
+      'https://wttc.org/DesktopModules/MVC/NewsArticleList/images/141_20201013185512_Consumer%20Survey%20Finds%2070%20Percent%20of%20Travelers%20Plan%20to%20Holiday%20in%202021.jpg',
+    href: 'https://www.koreanair.com/booking/best-prices?departureCode=ICN&destinationCode=HKT&cabin=Y&tripType=RT&duration=7',
+  },
+  {
+    id: 3,
+    location: '서울/인천 - 치앙마이',
+    seat: '일반석 왕복',
+    price: 839200,
+    image:
+      'https://wttc.org/DesktopModules/MVC/NewsArticleList/images/141_20201013185512_Consumer%20Survey%20Finds%2070%20Percent%20of%20Travelers%20Plan%20to%20Holiday%20in%202021.jpg',
+    href: 'https://www.koreanair.com/booking/best-prices?departureCode=ICN&destinationCode=CNX&cabin=Y&tripType=RT&duration=7',
+  },
+  {
+    id: 4,
+    location: '서울/인천 - 바르셀로나',
+    seat: '일반석 왕복',
+    price: 1546300,
+    image:
+      'https://wttc.org/DesktopModules/MVC/NewsArticleList/images/141_20201013185512_Consumer%20Survey%20Finds%2070%20Percent%20of%20Travelers%20Plan%20to%20Holiday%20in%202021.jpg',
+    href: 'https://www.koreanair.com/booking/best-prices?departureCode=ICN&destinationCode=BCN&cabin=Y&tripType=RT&duration=7',
+  },
+  {
+    id: 5,
+    location: '서울/인천 - 하노이',
+    seat: '일반석 왕복',
+    price: 527400,
+    image:
+      'https://wttc.org/DesktopModules/MVC/NewsArticleList/images/141_20201013185512_Consumer%20Survey%20Finds%2070%20Percent%20of%20Travelers%20Plan%20to%20Holiday%20in%202021.jpg',
+    href: 'https://www.koreanair.com/booking/best-prices?departureCode=ICN&destinationCode=HAN&cabin=Y&tripType=RT&duration=7',
+  },
+  {
+    id: 6,
+    location: '서울/인천 - 로마/레오나르도 다빈치',
+    seat: '일반석 왕복',
+    price: 1454300,
+    image:
+      'https://wttc.org/DesktopModules/MVC/NewsArticleList/images/141_20201013185512_Consumer%20Survey%20Finds%2070%20Percent%20of%20Travelers%20Plan%20to%20Holiday%20in%202021.jpg',
+    href: 'https://www.koreanair.com/booking/best-prices?departureCode=ICN&destinationCode=HNL&cabin=Y&tripType=RT&duration=7',
+  },
+  {
+    id: 7,
+    location: '서울/인천 - 호놀룰루(하와이)',
+    seat: '일반석 왕복',
+    price: 1244900,
+    image:
+      'https://wttc.org/DesktopModules/MVC/NewsArticleList/images/141_20201013185512_Consumer%20Survey%20Finds%2070%20Percent%20of%20Travelers%20Plan%20to%20Holiday%20in%202021.jpg',
+    href: 'https://www.koreanair.com/booking/best-prices?departureCode=ICN&destinationCode=HNL&cabin=Y&tripType=RT&duration=7',
+  },
+];


### PR DESCRIPTION
## 🔥 결과

직접 구현한 페이지를 작동시켜볼 수 있도록 접근 가능한 페이지 링크를 공유해주세요.

[링크](https://illustrious-travesseiro-f1eb42.netlify.app/)

## ✅ 요구사항 목록

**2 Carousel**

- [x] 총 8개의 carousel 중 2개의 목록을 기본으로 보여준다.
- [x] 실제 스크린 리더는 아래와 같이 읽을 수 있어야 합니다. 단, 스크린 리더기 마다 읽는 방법이 다를 수 있으니 참고만 해주세요. 중요한건 스크린 리더기를 활용하여 동작을 할 수 있어야 합니다.
- [x] 리팩터링 과정에서 불필요하거나 웹 표준에 어긋나는 마크업은 없는지 확인합니다.

```
1. 지금 떠나기 좋은 여행
2. 목록 8개 항목 포함 서울/인천 로스앤젤레스 일반석 왕복 1,481,800 대한민국 원 링크 목록 항목
3. 다음 버튼 (사용 중지)
4. 이전 버튼 (사용 중지)
```

## 🧐 공유

/_ 작업하면서 든 생각, 질문, 새롭게 학습하거나 시도해본 내용 등등 공유할 사항이 있다면 자유롭게 적어주세요 _/

`ul`, `li` 태그를 사용하여 캐러셀을 구현하니 스크린리더가 대부분 잘 읽어주더라구요! 시맨틱하게 작성해야하는 이유를 느꼈어요.

키보드로 동작을 할 때 h2 태그는 skip 하더라구요. 그래서 `tabIndex` 속성을 통해 키보드 동작에 반응하도록 했습니다.

저는 스크린리더를 사용하는 유저가 이전과 다음 버튼을 포커싱할 이유가 없다고 생각합니다.

처음에는 버튼에 aria-disabled 속성을 통해 사용 중지를 알려주는것이 좋다고생각했는데

아예 안 읽히는게 나은 것 같아서 aria-hidden을 주었고 tab동작에도 반응하지 않도록 tabIndex를 -1로 설정했습니다.