### PR TITLE
[항공사 웹사이트의 컴포넌트 접근성 높이기 - 2단계] 밧드(감우영) 미션 제출합니다.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,2 @@
+declare module '*.module.css';
+declare module '*.png';

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,13 +2,13 @@ import './style/normalize.css';
 import Body from './components/Body';
 import MessageContextProvider from './context/MessageContext';
 import A11yMessage from './components/A11yMessage';
-import PassengerPage from './pages/PassengerPage';
+import CarouselPage from './pages/CarouselPage';
 
 const App = () => {
   return (
     <MessageContextProvider>
       <Body>
-        <PassengerPage />
+        <CarouselPage />
       </Body>
       <A11yMessage />
     </MessageContextProvider>

--- a/src/components/Card/Card.module.css
+++ b/src/components/Card/Card.module.css
@@ -1,0 +1,36 @@
+.layout {
+  position: relative;
+  width: 340px;
+  height: 370px;
+}
+
+.description {
+  padding: 30px 20px;
+  position: absolute;
+}
+
+.bg-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.white-black-font {
+  color: white;
+  text-shadow: -2px 0 black, 0 2px black, 2px 0 black, 0 -2px black;
+}
+
+.title {
+  font-size: 25px;
+}
+
+.sub-title {
+  font-size: 20px;
+  margin-bottom: 10px;
+}
+
+.paragraph {
+  font-size: 20px;
+  color: navy;
+  text-shadow: -0.5px 0 white, 0 0.5px white, 0.5px 0 white, 0 -0.5px white;
+}

--- a/src/components/Card/Card.module.css
+++ b/src/components/Card/Card.module.css
@@ -1,6 +1,6 @@
 .layout {
   position: relative;
-  width: 340px;
+  width: 240px;
   height: 370px;
 }
 
@@ -30,6 +30,7 @@
 }
 
 .paragraph {
+  font-weight: 600;
   font-size: 20px;
   color: navy;
   text-shadow: -0.5px 0 white, 0 0.5px white, 0.5px 0 white, 0 -0.5px white;

--- a/src/components/Card/Card.module.css
+++ b/src/components/Card/Card.module.css
@@ -1,7 +1,12 @@
 .layout {
+  display: block;
   position: relative;
   width: 240px;
   height: 370px;
+}
+
+.layout:link {
+  color: inherit;
 }
 
 .description {

--- a/src/components/Card/Card.module.css
+++ b/src/components/Card/Card.module.css
@@ -5,10 +5,6 @@
   height: 370px;
 }
 
-.layout:link {
-  color: inherit;
-}
-
 .description {
   padding: 30px 20px;
   position: absolute;

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { CardInfo } from '../../type';
 import S from './Card.module.css';
 
@@ -5,18 +6,21 @@ type CardProps = {
   info: CardInfo;
 };
 
-const Card: React.FC<CardProps> = ({ info }) => {
+const Card: React.FC<CardProps & React.AnchorHTMLAttributes<HTMLAnchorElement>> = ({
+  info,
+  ...props
+}) => {
   return (
-    <div className={S.layout}>
+    <a href='https://www.koreanair.com/kr/ko' className={S.layout} tabIndex={props.tabIndex}>
       <div className={S.description}>
-        <h1 className={`${S.title} ${S['white-black-font']}`}>
+        <p className={`${S.title} ${S['white-black-font']}`}>
           {info.departure} - {info.arrival}
-        </h1>
+        </p>
         <p className={`${S['sub-title']} ${S['white-black-font']}`}>{info.type}</p>
         <p className={S.paragraph}>KRW {info.price.toLocaleString('ko-KR')} ~</p>
       </div>
       <img className={S['bg-img']} src={info.imageLink} alt={`${info.arrival} 사진`} />
-    </div>
+    </a>
   );
 };
 

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -4,16 +4,22 @@ import S from './Card.module.css';
 
 type CardProps = {
   info: CardInfo;
-};
+} & React.AnchorHTMLAttributes<HTMLAnchorElement>;
 
-const Card: React.FC<CardProps & React.AnchorHTMLAttributes<HTMLAnchorElement>> = ({
-  info,
-  ...props
-}) => {
+const Card: React.ForwardRefRenderFunction<HTMLAnchorElement, CardProps> = (
+  { info, ...props },
+  ref
+) => {
   return (
-    <a href='https://www.koreanair.com/kr/ko' className={S.layout} tabIndex={props.tabIndex}>
+    <a
+      href='https://www.koreanair.com/kr/ko'
+      className={S.layout}
+      tabIndex={props.tabIndex}
+      ref={ref}>
       <div className={S.description}>
-        <p className={`${S.title} ${S['white-black-font']}`}>
+        <p
+          className={`${S.title} ${S['white-black-font']}`}
+          aria-label={`${info.departure}출발 ${info.arrival}도착`}>
           {info.departure} - {info.arrival}
         </p>
         <p className={`${S['sub-title']} ${S['white-black-font']}`}>{info.type}</p>
@@ -24,4 +30,4 @@ const Card: React.FC<CardProps & React.AnchorHTMLAttributes<HTMLAnchorElement>> 
   );
 };
 
-export default Card;
+export default React.forwardRef(Card);

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -1,0 +1,23 @@
+import { CardInfo } from '../../type';
+import S from './Card.module.css';
+
+type CardProps = {
+  info: CardInfo;
+};
+
+const Card: React.FC<CardProps> = ({ info }) => {
+  return (
+    <div className={S.layout}>
+      <div className={S.description}>
+        <h1 className={`${S.title} ${S['white-black-font']}`}>
+          {info.departure} - {info.arrival}
+        </h1>
+        <p className={`${S['sub-title']} ${S['white-black-font']}`}>{info.type}</p>
+        <p className={S.paragraph}>KRW {info.price.toLocaleString('ko-KR')} ~</p>
+      </div>
+      <img className={S['bg-img']} src={info.imageLink} alt={`${info.arrival} 사진`} />
+    </div>
+  );
+};
+
+export default Card;

--- a/src/components/Carousel/Carousel.module.css
+++ b/src/components/Carousel/Carousel.module.css
@@ -11,6 +11,11 @@
   overflow-x: scroll;
 
   transition: ease 1s;
+  scrollbar-width: none;
+}
+
+.box::-webkit-scrollbar {
+  display: none;
 }
 
 .carousel-button {
@@ -23,7 +28,7 @@
   border: none;
   background-color: rgba(0, 0, 0, 0.3);
   color: white;
-
+  z-index: 10;
   cursor: pointer;
 }
 
@@ -35,4 +40,16 @@
 .right-button {
   border-radius: 25px 0 0 25px;
   right: 0;
+}
+
+.display-none {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
 }

--- a/src/components/Carousel/Carousel.module.css
+++ b/src/components/Carousel/Carousel.module.css
@@ -1,0 +1,38 @@
+.layout {
+  position: relative;
+  width: 1000px;
+}
+
+.box {
+  display: flex;
+  gap: 16px;
+  flex-wrap: nowrap;
+  overflow-y: hidden;
+  overflow-x: scroll;
+
+  transition: ease 1s;
+}
+
+.carousel-button {
+  width: 25px;
+  height: 50px;
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 15px;
+  border: none;
+  background-color: rgba(0, 0, 0, 0.3);
+  color: white;
+
+  cursor: pointer;
+}
+
+.left-button {
+  border-radius: 0 25px 25px 0;
+  left: 0;
+}
+
+.right-button {
+  border-radius: 25px 0 0 25px;
+  right: 0;
+}

--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -1,43 +1,67 @@
-import { useRef, useState } from 'react';
+import { useContext, useRef, useState } from 'react';
 import type { CardInfo } from '../../type';
 import Card from '../Card';
 import S from './Carousel.module.css';
+import { messageContext } from '../../context/MessageContext';
 
 type CarouselProps = {
   cardInfoList: CardInfo[];
 };
 
 const Carousel: React.FC<CarouselProps> = ({ cardInfoList }) => {
+  const messageState = useContext(messageContext);
   const [index, setIndex] = useState(0);
   const carouselRef = useRef<HTMLUListElement>(null);
 
-  const handleLeftClick = () => {
+  const handleLeftClick: React.MouseEventHandler<HTMLButtonElement> = () => {
     if (carouselRef.current && index > 0) {
       carouselRef.current.scrollBy({ left: -256, behavior: 'smooth' });
-      setIndex((prevIndex) => prevIndex - 1);
+      setIndex((prevIndex) => {
+        return prevIndex - 1;
+      });
+      return;
     }
+
+    messageState?.setMessage('사용 중지');
   };
 
-  const handleRightClick = () => {
+  const handleRightClick: React.MouseEventHandler<HTMLButtonElement> = () => {
     if (carouselRef.current && index < cardInfoList.length - 1) {
       carouselRef.current.scrollBy({ left: 256, behavior: 'smooth' });
       setIndex((prevIndex) => prevIndex + 1);
+      return;
     }
+
+    messageState?.setMessage('사용 중지');
   };
 
   return (
     <div className={S.layout}>
-      <ul className={S.box} ref={carouselRef}>
-        {cardInfoList.map((info) => (
-          <li key={info.id}>
-            <Card info={info} />
-          </li>
-        ))}
+      <ul className={S.box} ref={carouselRef} role='list'>
+        {cardInfoList.map((info, infoIndex) =>
+          index === infoIndex ? (
+            <li key={info.id} role='listitem'>
+              <Card info={info} />
+            </li>
+          ) : (
+            <li key={info.id} role='listitem' tabIndex={-1}>
+              <Card info={info} tabIndex={-1} />
+            </li>
+          )
+        )}
       </ul>
-      <button className={`${S['carousel-button']} ${S['left-button']}`} onClick={handleLeftClick}>
+      <button
+        aria-label='이전 목록'
+        className={`${S['carousel-button']} ${S['left-button']}`}
+        onClick={handleLeftClick}
+        tabIndex={0}>
         〈
       </button>
-      <button className={`${S['carousel-button']} ${S['right-button']}`} onClick={handleRightClick}>
+      <button
+        aria-label='다음 목록'
+        className={`${S['carousel-button']} ${S['right-button']}`}
+        onClick={handleRightClick}
+        tabIndex={0}>
         〉
       </button>
     </div>

--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -1,8 +1,9 @@
 import { useContext, useRef, useState } from 'react';
+import S from './Carousel.module.css';
 import type { CardInfo } from '../../type';
 import Card from '../Card';
-import S from './Carousel.module.css';
 import { messageContext } from '../../context/MessageContext';
+import { scrollByIndex } from '../../utils';
 
 type CarouselProps = {
   cardInfoList: CardInfo[];
@@ -12,13 +13,13 @@ const Carousel: React.FC<CarouselProps> = ({ cardInfoList }) => {
   const messageState = useContext(messageContext);
   const [index, setIndex] = useState(0);
   const carouselRef = useRef<HTMLUListElement>(null);
+  const itemRefs = useRef<(HTMLAnchorElement | null)[]>([]);
 
   const handleLeftClick: React.MouseEventHandler<HTMLButtonElement> = () => {
     if (carouselRef.current && index > 0) {
-      carouselRef.current.scrollBy({ left: -256, behavior: 'smooth' });
-      setIndex((prevIndex) => {
-        return prevIndex - 1;
-      });
+      scrollByIndex(carouselRef.current, itemRefs.current, index, 'left');
+      setIndex((prevIndex) => prevIndex - 1);
+
       return;
     }
 
@@ -27,25 +28,32 @@ const Carousel: React.FC<CarouselProps> = ({ cardInfoList }) => {
 
   const handleRightClick: React.MouseEventHandler<HTMLButtonElement> = () => {
     if (carouselRef.current && index < cardInfoList.length - 1) {
-      carouselRef.current.scrollBy({ left: 256, behavior: 'smooth' });
+      scrollByIndex(carouselRef.current, itemRefs.current, index, 'right');
       setIndex((prevIndex) => prevIndex + 1);
+
       return;
     }
 
     messageState?.setMessage('사용 중지');
   };
 
+  const bindItemRefs = (index: number) => (element: HTMLAnchorElement) => {
+    itemRefs.current[index] = element;
+
+    return element;
+  };
+
   return (
     <div className={S.layout}>
-      <ul className={S.box} ref={carouselRef} role='list'>
+      <ul className={S.box} ref={carouselRef}>
         {cardInfoList.map((info, infoIndex) =>
           index === infoIndex ? (
-            <li key={info.id} role='listitem'>
-              <Card info={info} />
+            <li key={info.id}>
+              <Card info={info} ref={bindItemRefs(infoIndex)} />
             </li>
           ) : (
-            <li key={info.id} role='listitem' tabIndex={-1}>
-              <Card info={info} tabIndex={-1} />
+            <li key={info.id} tabIndex={-1}>
+              <Card info={info} tabIndex={-1} ref={bindItemRefs(infoIndex)} />
             </li>
           )
         )}

--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -1,0 +1,47 @@
+import { useRef, useState } from 'react';
+import type { CardInfo } from '../../type';
+import Card from '../Card';
+import S from './Carousel.module.css';
+
+type CarouselProps = {
+  cardInfoList: CardInfo[];
+};
+
+const Carousel: React.FC<CarouselProps> = ({ cardInfoList }) => {
+  const [index, setIndex] = useState(0);
+  const carouselRef = useRef<HTMLUListElement>(null);
+
+  const handleLeftClick = () => {
+    if (carouselRef.current && index > 0) {
+      carouselRef.current.scrollBy({ left: -256, behavior: 'smooth' });
+      setIndex((prevIndex) => prevIndex - 1);
+    }
+  };
+
+  const handleRightClick = () => {
+    if (carouselRef.current && index < cardInfoList.length - 1) {
+      carouselRef.current.scrollBy({ left: 256, behavior: 'smooth' });
+      setIndex((prevIndex) => prevIndex + 1);
+    }
+  };
+
+  return (
+    <div className={S.layout}>
+      <ul className={S.box} ref={carouselRef}>
+        {cardInfoList.map((info) => (
+          <li key={info.id}>
+            <Card info={info} />
+          </li>
+        ))}
+      </ul>
+      <button className={`${S['carousel-button']} ${S['left-button']}`} onClick={handleLeftClick}>
+        〈
+      </button>
+      <button className={`${S['carousel-button']} ${S['right-button']}`} onClick={handleRightClick}>
+        〉
+      </button>
+    </div>
+  );
+};
+
+export default Carousel;

--- a/src/data/dummy.ts
+++ b/src/data/dummy.ts
@@ -2,6 +2,7 @@ import { CardInfo } from '../type';
 
 export const infoList: CardInfo[] = [
   {
+    id: 1,
     departure: '서울/인천',
     arrival: '두바이',
     type: '일반석 왕복',
@@ -10,6 +11,7 @@ export const infoList: CardInfo[] = [
       'https://res.klook.com/image/upload/c_crop,g_custom/w_1160,h_652/v1540285601/activities/gdf3czrtb4xx4qhfzvez.webp',
   },
   {
+    id: 2,
     departure: '서울/인천',
     arrival: '두바이',
     type: '일반석 왕복',
@@ -18,6 +20,7 @@ export const infoList: CardInfo[] = [
       'https://res.klook.com/image/upload/c_crop,g_custom/w_1160,h_652/v1540285601/activities/gdf3czrtb4xx4qhfzvez.webp',
   },
   {
+    id: 3,
     departure: '서울/인천',
     arrival: '두바이',
     type: '일반석 왕복',
@@ -26,6 +29,25 @@ export const infoList: CardInfo[] = [
       'https://res.klook.com/image/upload/c_crop,g_custom/w_1160,h_652/v1540285601/activities/gdf3czrtb4xx4qhfzvez.webp',
   },
   {
+    id: 4,
+    departure: '서울/인천',
+    arrival: '두바이',
+    type: '일반석 왕복',
+    price: 1121600,
+    imageLink:
+      'https://res.klook.com/image/upload/c_crop,g_custom/w_1160,h_652/v1540285601/activities/gdf3czrtb4xx4qhfzvez.webp',
+  },
+  {
+    id: 5,
+    departure: '서울/인천',
+    arrival: '두바이',
+    type: '일반석 왕복',
+    price: 1121600,
+    imageLink:
+      'https://res.klook.com/image/upload/c_crop,g_custom/w_1160,h_652/v1540285601/activities/gdf3czrtb4xx4qhfzvez.webp',
+  },
+  {
+    id: 6,
     departure: '서울/인천',
     arrival: '두바이',
     type: '일반석 왕복',

--- a/src/data/dummy.ts
+++ b/src/data/dummy.ts
@@ -13,46 +13,45 @@ export const infoList: CardInfo[] = [
   {
     id: 2,
     departure: '서울/인천',
-    arrival: '두바이',
+    arrival: '로스엔젤레스',
     type: '일반석 왕복',
-    price: 1121600,
+    price: 1721600,
     imageLink:
-      'https://res.klook.com/image/upload/c_crop,g_custom/w_1160,h_652/v1540285601/activities/gdf3czrtb4xx4qhfzvez.webp',
+      'https://d2ur7st6jjikze.cloudfront.net/offer_photos/32949/206415_large_1521658778.jpg?1521658778',
   },
   {
     id: 3,
     departure: '서울/인천',
-    arrival: '두바이',
+    arrival: '호롤룰루',
     type: '일반석 왕복',
-    price: 1121600,
+    price: 1341600,
     imageLink:
-      'https://res.klook.com/image/upload/c_crop,g_custom/w_1160,h_652/v1540285601/activities/gdf3czrtb4xx4qhfzvez.webp',
+      'https://media.triple.guide/triple-cms/c_limit,f_auto,h_1024,w_1024/1bed56a8-e298-4c8d-a2eb-3c8307efe904.jpeg',
   },
   {
     id: 4,
     departure: '서울/인천',
-    arrival: '두바이',
+    arrival: '괌',
     type: '일반석 왕복',
-    price: 1121600,
+    price: 1241600,
     imageLink:
-      'https://res.klook.com/image/upload/c_crop,g_custom/w_1160,h_652/v1540285601/activities/gdf3czrtb4xx4qhfzvez.webp',
+      'https://www.lottehotelmagazine.com/resources/4ceaf51f-8225-435b-b233-d79ecc5dc68d_img_travel_guam_detail01.jpg',
   },
   {
     id: 5,
     departure: '서울/인천',
-    arrival: '두바이',
+    arrival: '스위스',
     type: '일반석 왕복',
     price: 1121600,
     imageLink:
-      'https://res.klook.com/image/upload/c_crop,g_custom/w_1160,h_652/v1540285601/activities/gdf3czrtb4xx4qhfzvez.webp',
+      'https://post-phinf.pstatic.net/MjAxOTAyMjZfMTU0/MDAxNTUxMTQ4NjY0MjE4.7napanJWu5a44xN90w46MyB6nh_YBhssOg9B3XbgJRYg.YPWrrB5OkxxSZbCmKw-cbxZREVPBZUnOWSPAiPktM7gg.JPEG/%EC%8A%A4%EC%9C%84%EC%8A%A4%EC%97%AC%ED%96%89%EC%BD%94%EC%8A%A43.jpg?type=w1200',
   },
   {
     id: 6,
     departure: '서울/인천',
-    arrival: '두바이',
+    arrival: '영국',
     type: '일반석 왕복',
-    price: 1121600,
-    imageLink:
-      'https://res.klook.com/image/upload/c_crop,g_custom/w_1160,h_652/v1540285601/activities/gdf3czrtb4xx4qhfzvez.webp',
+    price: 2121600,
+    imageLink: 'http://www.hellotravel.kr/data/local/list/150753123438.jpg',
   },
 ];

--- a/src/data/dummy.ts
+++ b/src/data/dummy.ts
@@ -1,0 +1,36 @@
+import { CardInfo } from '../type';
+
+export const infoList: CardInfo[] = [
+  {
+    departure: '서울/인천',
+    arrival: '두바이',
+    type: '일반석 왕복',
+    price: 1121600,
+    imageLink:
+      'https://res.klook.com/image/upload/c_crop,g_custom/w_1160,h_652/v1540285601/activities/gdf3czrtb4xx4qhfzvez.webp',
+  },
+  {
+    departure: '서울/인천',
+    arrival: '두바이',
+    type: '일반석 왕복',
+    price: 1121600,
+    imageLink:
+      'https://res.klook.com/image/upload/c_crop,g_custom/w_1160,h_652/v1540285601/activities/gdf3czrtb4xx4qhfzvez.webp',
+  },
+  {
+    departure: '서울/인천',
+    arrival: '두바이',
+    type: '일반석 왕복',
+    price: 1121600,
+    imageLink:
+      'https://res.klook.com/image/upload/c_crop,g_custom/w_1160,h_652/v1540285601/activities/gdf3czrtb4xx4qhfzvez.webp',
+  },
+  {
+    departure: '서울/인천',
+    arrival: '두바이',
+    type: '일반석 왕복',
+    price: 1121600,
+    imageLink:
+      'https://res.klook.com/image/upload/c_crop,g_custom/w_1160,h_652/v1540285601/activities/gdf3czrtb4xx4qhfzvez.webp',
+  },
+];

--- a/src/pages/CarouselPage/CarouselPage.module.css
+++ b/src/pages/CarouselPage/CarouselPage.module.css
@@ -1,0 +1,12 @@
+.layout {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.box {
+  width: 1000px;
+  overflow-x: hidden;
+}

--- a/src/pages/CarouselPage/index.tsx
+++ b/src/pages/CarouselPage/index.tsx
@@ -1,0 +1,15 @@
+import Carousel from '../../components/Carousel';
+import { infoList } from '../../data/dummy';
+import S from './CarouselPage.module.css';
+
+const CarouselPage = () => {
+  return (
+    <div className={S.layout}>
+      <section className={S.box}>
+        <Carousel cardInfoList={infoList} />
+      </section>
+    </div>
+  );
+};
+
+export default CarouselPage;

--- a/src/pages/CarouselPage/index.tsx
+++ b/src/pages/CarouselPage/index.tsx
@@ -5,7 +5,8 @@ import S from './CarouselPage.module.css';
 const CarouselPage = () => {
   return (
     <div className={S.layout}>
-      <section className={S.box}>
+      <section className={S.box} aria-labelledby='TRIP_HD'>
+        <h1 id='TRIP_HD'>지금 떠나기 좋은 여행</h1>
         <Carousel cardInfoList={infoList} />
       </section>
     </div>

--- a/src/style/normalize.css
+++ b/src/style/normalize.css
@@ -349,3 +349,7 @@ template {
 [hidden] {
   display: none;
 }
+
+p {
+  margin: 0;
+}

--- a/src/style/normalize.css
+++ b/src/style/normalize.css
@@ -8,6 +8,10 @@
    * 2. Prevent adjustments of font size after orientation changes in iOS.
    */
 
+* {
+  box-sizing: border-box;
+}
+
 html {
   line-height: 1.15; /* 1 */
   -webkit-text-size-adjust: 100%; /* 2 */
@@ -352,4 +356,9 @@ template {
 
 p {
   margin: 0;
+}
+
+ul {
+  list-style: none;
+  padding: 0;
 }

--- a/src/type/index.ts
+++ b/src/type/index.ts
@@ -1,0 +1,7 @@
+export type CardInfo = {
+  departure: string;
+  arrival: string;
+  type: string;
+  price: number;
+  imageLink: string;
+};

--- a/src/type/index.ts
+++ b/src/type/index.ts
@@ -1,4 +1,5 @@
 export type CardInfo = {
+  id: number;
   departure: string;
   arrival: string;
   type: string;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,21 @@
+export const scrollByIndex = <F extends HTMLElement, I extends (HTMLElement | null)[]>(
+  frame: F,
+  items: I,
+  currentIndex: number,
+  direction: 'left' | 'right'
+) => {
+  const targetIndex = direction === 'left' ? currentIndex - 1 : currentIndex + 1;
+  const currentLeftPosition = items[currentIndex]?.getBoundingClientRect().left;
+  const targetLeftPosition = items[targetIndex]?.getBoundingClientRect().left;
+
+  if (!currentLeftPosition || !targetLeftPosition) {
+    return;
+  }
+
+  const scrollWidth = Math.abs(currentLeftPosition - targetLeftPosition);
+
+  frame.scrollBy({
+    left: direction === 'left' ? scrollWidth * -1 : scrollWidth,
+    behavior: 'smooth',
+  });
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,5 +11,5 @@
     "jsx": "preserve",
     "allowSyntheticDefaultImports": true
   },
-  "include": ["src"]
+  "include": ["src", "index.d.ts"]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,8 +18,13 @@ module.exports = {
         loader: 'babel-loader',
       },
       {
-        test: /\.css$/,
+        test: /\.css$/i,
+        exclude: /\.module\.css$/i,
         use: ['style-loader', 'css-loader'],
+      },
+      {
+        test: /\.module\.css$/i,
+        use: ['style-loader', { loader: 'css-loader', options: { modules: true } }],
       },
       {
         test: /\.(png|svg|jpg|jpeg|gif|ico)$/i,
@@ -39,7 +44,7 @@ module.exports = {
     static: {
       directory: join(__dirname, './public'),
     },
-    port: 3000,
+    port: 3001,
     hot: true,
     compress: true,
     client: {


### PR DESCRIPTION
## 🔥 결과

직접 구현한 페이지를 작동시켜볼 수 있도록 접근 가능한 페이지 링크를 공유해주세요.

[링크](https://kamwoo.github.io/a11y-airline/)

## ✅ 요구사항 목록


**2 Carousel**

- [x] 총 8개의 carousel 중 2개의 목록을 기본으로 보여준다.
- [x] 실제 스크린 리더는 아래와 같이 읽을 수 있어야 합니다. 단, 스크린 리더기 마다 읽는 방법이 다를 수 있으니 참고만 해주세요. 중요한건 스크린 리더기를 활용하여 동작을 할 수 있어야 합니다.
- [x] 리팩터링 과정에서 불필요하거나 웹 표준에 어긋나는 마크업은 없는지 확인합니다.

```
1. 지금 떠나기 좋은 여행
2. 목록 8개 항목 포함 서울/인천 로스앤젤레스 일반석 왕복 1,481,800 대한민국 원 링크 목록 항목
3. 다음 버튼 (사용 중지)
4. 이전 버튼 (사용 중지)
```

## 🧐 공유

/_ 작업하면서 든 생각, 질문, 새롭게 학습하거나 시도해본 내용 등등 공유할 사항이 있다면 자유롭게 적어주세요 _/
1. tab이동을 통해서 원하는 아이템을 포커스하고 바로 버튼으로 이동하는데에 시간이 걸렸습니다. `tabIndex`를 사용해서 해당하는 아이템이 아니라면 tab이동을 막았습니다. 
고민이 되는 것은 지금 동작하는 과정은 아이템 -> 왼쪽 버튼 -> 오른쪽 버튼이고,
오른쪽 이동 버튼을 클릭하고 나서는 `shift + tab`으로 다시 아이템에 접근해야하는게 불편하지 않을까 생각합니다.
앨버는 어떻게 생각하시나요?
