### PR TITLE
[항공사 웹사이트의 컴포넌트 접근성 높이기 - 2단계] 아놀드(한수빈) 미션 제출합니다.

### DIFF
--- a/carousel.html
+++ b/carousel.html
@@ -150,8 +150,16 @@
           </li>
         </ul>
         <div class="button-wrapper">
-          <button class="prev-button button"></button>
-          <button class="next-button button"></button>
+          <button
+            class="prev-button button"
+            aria-label="이전"
+            aria-atomic="true"
+          ></button>
+          <button
+            class="next-button button"
+            aria-label="다음"
+            aria-atomic="true"
+          ></button>
         </div>
       </article>
     </section>

--- a/carousel.html
+++ b/carousel.html
@@ -25,7 +25,8 @@
               <div class="content-wrapper">
                 <p class="location">서울/인천 - 두바이</p>
                 <p class="seat">일반석 왕복</p>
-                <p class="price">KRW 1,121,600 ~</p>
+                <span class="price">KRW 1,121,600</span>
+                <span class="price" aria-hidden="true">~</span>
               </div>
             </a>
           </li>
@@ -42,7 +43,8 @@
               <div class="content-wrapper">
                 <p class="location">서울/인천 - 후쿠오카</p>
                 <p class="seat">일반석 왕복</p>
-                <p class="price">KRW 340,400 ~</p>
+                <span class="price">KRW 340,400</span>
+                <span class="price" aria-hidden="true">~</span>
               </div>
             </a>
           </li>
@@ -59,7 +61,8 @@
               <div class="content-wrapper">
                 <p class="location">서울/인천 - 푸껫</p>
                 <p class="seat">일반석 왕복</p>
-                <p class="price">KRW 704,200 ~</p>
+                <span class="price">KRW 704,200</span>
+                <span class="price" aria-hidden="true">~</span>
               </div>
             </a>
           </li>
@@ -76,7 +79,8 @@
               <div class="content-wrapper">
                 <p class="location">서울/인천 - 치앙마이</p>
                 <p class="seat">일반석 왕복</p>
-                <p class="price">KRW 839,100 ~</p>
+                <span class="price">KRW 839,100</span>
+                <span class="price" aria-hidden="true">~</span>
               </div>
             </a>
           </li>
@@ -93,7 +97,8 @@
               <div class="content-wrapper">
                 <p class="location">서울/인천 - 바르셀로나</p>
                 <p class="seat">일반석 왕복</p>
-                <p class="price">KRW 1,546,300 ~</p>
+                <span class="price">KRW 1,546,300</span>
+                <span class="price" aria-hidden="true">~</span>
               </div>
             </a>
           </li>
@@ -110,7 +115,8 @@
               <div class="content-wrapper">
                 <p class="location">서울/인천 - 하노이</p>
                 <p class="seat">일반석 왕복</p>
-                <p class="price">KRW 527,500 ~</p>
+                <span class="price">KRW 527,500</span>
+                <span class="price" aria-hidden="true">~</span>
               </div>
             </a>
           </li>
@@ -127,7 +133,8 @@
               <div class="content-wrapper">
                 <p class="location">서울/인천 - 로마/레오나르도 다빈치</p>
                 <p class="seat">일반석 왕복</p>
-                <p class="price">KRW 1,454,200 ~</p>
+                <span class="price">KRW 1,454,200</span>
+                <span class="price" aria-hidden="true">~</span>
               </div>
             </a>
           </li>
@@ -144,7 +151,8 @@
               <div class="content-wrapper">
                 <p class="location">서울/인천 - 호놀룰루 (하와이)</p>
                 <p class="seat">일반석 왕복</p>
-                <p class="price">KRW 1,244,900 ~</p>
+                <span class="price">KRW 1,244,900</span>
+                <span class="price" aria-hidden="true">~</span>
               </div>
             </a>
           </li>

--- a/carousel.html
+++ b/carousel.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Carousel</title>
+    <link rel="stylesheet" href="./src/carousel.css" />
+  </head>
+  <body>
+    <section>
+      <h1>지금 떠나기 좋은 여행</h1>
+      <article class="item-container">
+        <ul class="item-list">
+          <li class="item" data-id="0">
+            <a
+              class="item-link"
+              href="https://www.koreanair.com/booking/best-prices?departureCode=ICN&destinationCode=DXB&duration=7&cabin=Y"
+            >
+              <img
+                src="https://www.koreanair.com/content/dam/koreanair/ko/airport-img/DXB-list-pc.jpg"
+                alt=""
+                class="item-image"
+              />
+              <div class="content-wrapper">
+                <p class="location">서울/인천 - 두바이</p>
+                <p class="seat">일반석 왕복</p>
+                <p class="price">KRW 1,121,600 ~</p>
+              </div>
+            </a>
+          </li>
+          <li class="item" data-id="1">
+            <a
+              class="item-link"
+              href="https://www.koreanair.com/booking/best-prices?departureCode=ICN&destinationCode=FUK&cabin=Y&tripType=RT&duration=7"
+            >
+              <img
+                src="https://www.koreanair.com/content/dam/koreanair/ko/airport-img/FUK-list-pc.jpg"
+                alt=""
+                class="item-image"
+              />
+              <div class="content-wrapper">
+                <p class="location">서울/인천 - 후쿠오카</p>
+                <p class="seat">일반석 왕복</p>
+                <p class="price">KRW 340,400 ~</p>
+              </div>
+            </a>
+          </li>
+          <li class="item" data-id="2">
+            <a
+              class="item-link"
+              href="https://www.koreanair.com/booking/best-prices?departureCode=ICN&destinationCode=HKT&cabin=Y&tripType=RT&duration=7"
+            >
+              <img
+                src="https://www.koreanair.com/content/dam/koreanair/ko/airport-img/HKT-list-pc.jpg"
+                alt=""
+                class="item-image"
+              />
+              <div class="content-wrapper">
+                <p class="location">서울/인천 - 푸껫</p>
+                <p class="seat">일반석 왕복</p>
+                <p class="price">KRW 704,200 ~</p>
+              </div>
+            </a>
+          </li>
+          <li class="item" data-id="3">
+            <a
+              class="item-link"
+              href="https://www.koreanair.com/booking/best-prices?departureCode=ICN&destinationCode=CNX&duration=7&cabin=Y"
+            >
+              <img
+                src="https://www.koreanair.com/content/dam/koreanair/ko/airport-img/CNX-list-pc.jpg"
+                alt=""
+                class="item-image"
+              />
+              <div class="content-wrapper">
+                <p class="location">서울/인천 - 치앙마이</p>
+                <p class="seat">일반석 왕복</p>
+                <p class="price">KRW 839,100 ~</p>
+              </div>
+            </a>
+          </li>
+          <li class="item" data-id="4">
+            <a
+              class="item-link"
+              href="https://www.koreanair.com/booking/best-prices?departureCode=ICN&destinationCode=BCN&cabin=Y&tripType=RT&duration=7"
+            >
+              <img
+                src="https://www.koreanair.com/content/dam/koreanair/ko/airport-img/BCN-list-pc.jpg"
+                alt=""
+                class="item-image"
+              />
+              <div class="content-wrapper">
+                <p class="location">서울/인천 - 바르셀로나</p>
+                <p class="seat">일반석 왕복</p>
+                <p class="price">KRW 1,546,300 ~</p>
+              </div>
+            </a>
+          </li>
+          <li class="item" data-id="5">
+            <a
+              class="item-link"
+              href="https://www.koreanair.com/booking/best-prices?departureCode=ICN&destinationCode=HAN&cabin=Y&tripType=RT&duration=7"
+            >
+              <img
+                src="https://www.koreanair.com/content/dam/koreanair/ko/airport-img/HAN-list-pc.jpg"
+                alt=""
+                class="item-image"
+              />
+              <div class="content-wrapper">
+                <p class="location">서울/인천 - 하노이</p>
+                <p class="seat">일반석 왕복</p>
+                <p class="price">KRW 527,500 ~</p>
+              </div>
+            </a>
+          </li>
+          <li class="item" data-id="6">
+            <a
+              class="item-link"
+              href="https://www.koreanair.com/booking/best-prices?departureCode=ICN&destinationCode=FCO&cabin=Y&tripType=RT&duration=7"
+            >
+              <img
+                src="https://www.koreanair.com/content/dam/koreanair/ko/airport-img/FCO-list-pc.jpg"
+                alt=""
+                class="item-image"
+              />
+              <div class="content-wrapper">
+                <p class="location">서울/인천 - 로마/레오나르도 다빈치</p>
+                <p class="seat">일반석 왕복</p>
+                <p class="price">KRW 1,454,200 ~</p>
+              </div>
+            </a>
+          </li>
+          <li class="item" data-id="7">
+            <a
+              class="item-link"
+              href="https://www.koreanair.com/booking/best-prices?departureCode=ICN&destinationCode=HNL&cabin=Y&tripType=RT&duration=7"
+            >
+              <img
+                src="https://www.koreanair.com/content/dam/koreanair/ko/airport-img/HNL-list-pc.jpg"
+                alt=""
+                class="item-image"
+              />
+              <div class="content-wrapper">
+                <p class="location">서울/인천 - 호놀룰루 (하와이)</p>
+                <p class="seat">일반석 왕복</p>
+                <p class="price">KRW 1,244,900 ~</p>
+              </div>
+            </a>
+          </li>
+        </ul>
+        <div class="button-wrapper">
+          <button class="prev-button button"></button>
+          <button class="next-button button"></button>
+        </div>
+      </article>
+    </section>
+    <script src="./src/carousel.js"></script>
+  </body>
+</html>

--- a/src/carousel.css
+++ b/src/carousel.css
@@ -1,0 +1,96 @@
+* {
+  box-sizing: border-box;
+  padding: 0;
+}
+
+p {
+  margin: 0;
+}
+
+ul {
+  list-style: none;
+}
+
+a {
+  text-decoration: none;
+  color: inherit;
+}
+
+.item-container {
+  position: relative;
+  width: 500px;
+  overflow: hidden;
+}
+
+.item-list {
+  display: flex;
+  gap: 40px;
+}
+
+.item {
+  position: relative;
+}
+
+.item-link {
+  display: block;
+}
+
+.item-image {
+  width: 230px;
+  height: 300px;
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: cover;
+  border-radius: 8px;
+}
+
+.content-wrapper {
+  position: absolute;
+  top: 0px;
+  padding: 20px 22px;
+}
+
+.location {
+  margin-bottom: 10px;
+  font-weight: bold;
+  font-size: 18px;
+}
+
+.seat {
+  margin-bottom: 4px;
+}
+
+.price {
+  color: #11277b;
+  font-weight: bold;
+  font-size: 18px;
+}
+
+.button-wrapper {
+  position: absolute;
+  top: 130px;
+  width: 500px;
+}
+
+.button {
+  width: 30px;
+  height: 60px;
+  border: none;
+  cursor: pointer;
+}
+
+.prev-button {
+  position: absolute;
+  left: 0;
+  background: url('https://www.koreanair.com/etc.clientlibs/koreanair/clientlibs/clientlib-base/resources/images/mris__button-left.svg')
+    no-repeat center top;
+  background-size: 30px 60px;
+}
+
+.next-button {
+  position: absolute;
+  right: 0;
+  background: url('https://www.koreanair.com/etc.clientlibs/koreanair/clientlibs/clientlib-base/resources/images/mris__button-right.svg')
+    no-repeat right top;
+  background-size: 30px 60px;
+}

--- a/src/carousel.js
+++ b/src/carousel.js
@@ -1,0 +1,51 @@
+let itemIndex = 0;
+
+const transformItemList = () => {
+  document.querySelectorAll('.item').forEach((item) => {
+    item.animate(
+      [
+        {
+          transform: `translateX(calc((-270px) * ${itemIndex}))`,
+        },
+      ],
+      {
+        duration: 300,
+        fill: 'forwards',
+      }
+    );
+  });
+};
+
+document.querySelector('.prev-button').addEventListener('click', () => {
+  if (itemIndex === 0) return;
+
+  if (itemIndex === 1)
+    document.querySelector('.prev-button').ariaDisabled = 'true';
+  if (itemIndex === 6)
+    document.querySelector('.next-button').ariaDisabled = 'false';
+
+  itemIndex -= 1;
+  transformItemList();
+});
+
+document.querySelector('.next-button').addEventListener('click', () => {
+  if (itemIndex === 6) return;
+
+  if (itemIndex === 5)
+    document.querySelector('.next-button').ariaDisabled = 'true';
+  if (itemIndex === 0)
+    document.querySelector('.prev-button').ariaDisabled = 'false';
+
+  itemIndex += 1;
+  transformItemList();
+});
+
+document.querySelectorAll('.item-link').forEach((item) => {
+  item.addEventListener('focus', () => {
+    const itemId = Number(item.closest('li').dataset.id);
+    if (itemId === 7) return;
+
+    itemIndex = itemId;
+    if (itemId > 0) transformItemList();
+  });
+});


### PR DESCRIPTION
## 🔥 결과

직접 구현한 페이지를 작동시켜볼 수 있도록 접근 가능한 페이지 링크를 공유해주세요.

[링크](https://sanaandmomo.github.io/a11y-airline/carousel.html)

## ✅ 요구사항 목록

**2 Carousel**

- [x] 총 8개의 carousel 중 2개의 목록을 기본으로 보여준다.
- [x] 실제 스크린 리더는 아래와 같이 읽을 수 있어야 합니다. 단, 스크린 리더기 마다 읽는 방법이 다를 수 있으니 참고만 해주세요. 중요한건 스크린 리더기를 활용하여 동작을 할 수 있어야 합니다.
- [x] 리팩터링 과정에서 불필요하거나 웹 표준에 어긋나는 마크업은 없는지 확인합니다.

```
1. 지금 떠나기 좋은 여행
2. 목록 8개 항목 포함 서울/인천 로스앤젤레스 일반석 왕복 1,481,800 대한민국 원 링크 목록 항목
3. 다음 버튼 (사용 중지)
4. 이전 버튼 (사용 중지)
```

## 🧐 공유

테코톡 하느라 이제 제출하네요 ㅠㅠ 양해 부탁드려요 결~
이번 미션은 캐러셀을 구현하는 게 최고 어렵지 않았나 싶네요.
물론 혼자선 못하겠어서 크루분들의 코드를 많이 참고했습니다.
