### PR TITLE
[항공사 웹사이트의 컴포넌트 접근성 높이기] 리버(최재희) 미션 제출합니다.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,15 +1,13 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>A11Y AIRLINE - 안전하고 쾌적한 여행</title>
+  </head>
 
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>React App</title>
-</head>
-
-<body>
-  <div id="root"></div>
-  <script type="module" src="/src/main.tsx"></script>
-</body>
-
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "deploy": "npm run build && npx gh-pages -d dist"
   },
   "author": "woowacourse",
-  "homepage": "https://{username}.github.io/a11y-airline",
+  "homepage": "https://0jenn0.github.io/a11y-airline",
   "license": "MIT",
   "dependencies": {
     "react": "^18.3.1",

--- a/src/App.module.css
+++ b/src/App.module.css
@@ -43,15 +43,16 @@
 
 .skipLink {
   position: absolute;
-  top: -40px;
+  top: 0;
   left: 0;
   background: #000;
   color: white;
   padding: 8px;
   z-index: 100;
-  transition: top 0.3s;
+  transform: translateY(-100%);
+  transition: transform 0.3s;
 }
 
 .skipLink:focus {
-  top: 0;
+  transform: translateY(0);
 }

--- a/src/App.module.css
+++ b/src/App.module.css
@@ -40,3 +40,18 @@
   background-color: white;
   text-align: center;
 }
+
+.skipLink {
+  position: absolute;
+  top: -40px;
+  left: 0;
+  background: #000;
+  color: white;
+  padding: 8px;
+  z-index: 100;
+  transition: top 0.3s;
+}
+
+.skipLink:focus {
+  top: 0;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,14 +7,18 @@ import TravelSection from './components/TravelSection';
 function App() {
   return (
     <div className={styles.app}>
-      <Navigation />
-      <div className={styles.header}>
+      <nav>
+        <Navigation />
+      </nav>
+
+      <header className={styles.header}>
         <h1 className={`${styles.title} heading-1-text`}>A11Y AIRLINE</h1>
         <p className="body-text">
           A11Y AIRLINE은 고객 여러분의 안전하고 쾌적한 여행을 위해 최선을 다하고 있습니다.
         </p>
-      </div>
-      <div id="main-content" className={styles.main}>
+      </header>
+
+      <main id="main-content" className={styles.main}>
         <div className={styles.flightBooking}>
           <FlightBooking />
         </div>
@@ -22,10 +26,11 @@ function App() {
           <h1 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h1>
           <TravelSection />
         </div>
-      </div>
-      <div className={styles.footer}>
+      </main>
+
+      <footer className={styles.footer}>
         <p className="body-text">&copy; A11Y AIRLINE</p>
-      </div>
+      </footer>
       {/* 추가 CHALLENGE: 모달 포커스 트랩 */}
       {/* <PromotionModal /> */}
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,7 +27,7 @@ function App() {
           <FlightBooking />
         </div>
         <div className={styles.travelSection}>
-          <h1 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h1>
+          <h2 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h2>
           <TravelSection />
         </div>
       </main>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,10 @@ import TravelSection from './components/TravelSection';
 function App() {
   return (
     <div className={styles.app}>
+      <a href="#main-content" className={styles.skipLink}>
+        본문으로 바로가기
+      </a>
+
       <nav>
         <Navigation />
       </nav>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,13 +23,13 @@ function App() {
       </header>
 
       <main id="main-content" className={styles.main}>
-        <div className={styles.flightBooking}>
+        <section className={styles.flightBooking}>
           <FlightBooking />
-        </div>
-        <div className={styles.travelSection}>
+        </section>
+        <section className={styles.travelSection}>
           <h2 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h2>
           <TravelSection />
-        </div>
+        </section>
       </main>
 
       <footer className={styles.footer}>

--- a/src/components/FlightBooking.module.css
+++ b/src/components/FlightBooking.module.css
@@ -3,6 +3,9 @@
   border-radius: 8px;
   padding: 20px;
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
 
 .passengerLabel {

--- a/src/components/Navigation.module.css
+++ b/src/components/Navigation.module.css
@@ -61,6 +61,7 @@
 }
 
 .navToggle {
+  width: 100%;
   display: none;
   font-size: 16px;
   padding: 10px;

--- a/src/components/TravelSection.module.css
+++ b/src/components/TravelSection.module.css
@@ -21,6 +21,7 @@
 
 .cardActive {
   display: block;
+  text-align: left;
 }
 
 .cardImage {

--- a/src/components/TravelSection.module.css
+++ b/src/components/TravelSection.module.css
@@ -17,7 +17,6 @@
   display: none;
   width: 100%;
   height: 246px;
-  color: rgba(0, 0, 0);
 }
 
 .cardActive {

--- a/src/components/TravelSection.module.css
+++ b/src/components/TravelSection.module.css
@@ -17,6 +17,7 @@
   display: none;
   width: 100%;
   height: 246px;
+  color: rgba(0, 0, 0);
 }
 
 .cardActive {

--- a/src/components/TravelSection.module.css
+++ b/src/components/TravelSection.module.css
@@ -74,13 +74,11 @@
 .navButtonPrev {
   left: 0;
   border-radius: 0 40px 40px 0;
-  padding-left: 15px;
 }
 
 .navButtonNext {
   right: 0;
   border-radius: 40px 0 0 40px;
-  padding-right: 15px;
 }
 
 .navButtonIcon {

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -45,6 +45,13 @@ const travelOptions: TravelOption[] = [
 ];
 
 const totalCount = travelOptions.length;
+
+const getAriaLabel = (option: TravelOption) => {
+  return `${option.departure} 출발 ${option.destination} 도착 ${
+    option.type
+  } 가격 ${option.price.toLocaleString()}원. 선택하면 예약 페이지로 이동합니다.`;
+};
+
 const TravelSection = () => {
   const [currentIndex, setCurrentIndex] = useState(0);
 
@@ -70,12 +77,15 @@ const TravelSection = () => {
       </button>
       <div className={styles.carousel}>
         {travelOptions.map((option, index) => (
-          <div
+          <button
+            type="button"
             key={index}
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
             onClick={() => handleCardClick(option.link)}
+            aria-live="polite"
+            aria-label={getAriaLabel(option)}
           >
-            <img src={option.image} className={styles.cardImage} />
+            <img src={option.image} className={styles.cardImage} alt="" />
             <div className={styles.cardContent}>
               <p className={`${styles.cardTitle} heading-3-text`}>
                 {option.departure} - {option.destination}
@@ -83,7 +93,7 @@ const TravelSection = () => {
               <p className={`${styles.cardType} body-text`}>{option.type}</p>
               <p className={`${styles.cardPrice} body-text`}>KRW {option.price.toLocaleString()}</p>
             </div>
-          </div>
+          </button>
         ))}
       </div>
       <button className={`${styles.navButton} ${styles.navButtonNext}`} onClick={nextTravel}>

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -44,6 +44,7 @@ const travelOptions: TravelOption[] = [
   }
 ];
 
+const totalCount = travelOptions.length;
 const TravelSection = () => {
   const [currentIndex, setCurrentIndex] = useState(0);
 
@@ -61,6 +62,9 @@ const TravelSection = () => {
 
   return (
     <div className={styles.travelSection}>
+      <p className="visually-hidden">
+        {`${totalCount}개의 여행 상품 중 ${currentIndex + 1}번 째 상품`}
+      </p>
       <button className={`${styles.navButton} ${styles.navButtonPrev}`} onClick={prevTravel}>
         <img src={chevronLeft} className={styles.navButtonIcon} />
       </button>

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -72,8 +72,13 @@ const TravelSection = () => {
       <p className="visually-hidden">
         {`${totalCount}개의 여행 상품 중 ${currentIndex + 1}번 째 상품`}
       </p>
-      <button className={`${styles.navButton} ${styles.navButtonPrev}`} onClick={prevTravel}>
-        <img src={chevronLeft} className={styles.navButtonIcon} />
+      <button
+        type="button"
+        aria-label="이전 여행 상품"
+        className={`${styles.navButton} ${styles.navButtonPrev}`}
+        onClick={prevTravel}
+      >
+        <img src={chevronLeft} className={styles.navButtonIcon} alt="" />
       </button>
       <div className={styles.carousel}>
         {travelOptions.map((option, index) => (
@@ -96,8 +101,13 @@ const TravelSection = () => {
           </button>
         ))}
       </div>
-      <button className={`${styles.navButton} ${styles.navButtonNext}`} onClick={nextTravel}>
-        <img src={chevronRight} className={styles.navButtonIcon} />
+      <button
+        type="button"
+        aria-label="다음 여행 상품"
+        className={`${styles.navButton} ${styles.navButtonNext}`}
+        onClick={nextTravel}
+      >
+        <img src={chevronRight} className={styles.navButtonIcon} alt="" />
       </button>
     </div>
   );

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -63,10 +63,6 @@ const TravelSection = () => {
     setCurrentIndex((prevIndex) => (prevIndex - 1 + travelOptions.length) % travelOptions.length);
   };
 
-  const handleCardClick = (link: string) => {
-    window.open(link, '_blank', 'noopener,noreferrer');
-  };
-
   return (
     <div className={styles.travelSection}>
       <p className="visually-hidden">
@@ -82,23 +78,24 @@ const TravelSection = () => {
       </button>
       <div className={styles.carousel}>
         {travelOptions.map((option, index) => (
-          <button
-            type="button"
+          <a
             key={index}
+            href={option.link}
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
-            onClick={() => handleCardClick(option.link)}
-            aria-live="polite"
             aria-label={getAriaLabel(option)}
+            aria-live="polite"
+            target="_blank"
+            rel="noopener noreferrer"
           >
-            <img src={option.image} className={styles.cardImage} alt="" />
-            <div className={styles.cardContent}>
+            <img src={option.image} className={styles.cardImage} alt="" aria-hidden="true" />
+            <div className={styles.cardContent} aria-hidden="true">
               <p className={`${styles.cardTitle} heading-3-text`}>
                 {option.departure} - {option.destination}
               </p>
               <p className={`${styles.cardType} body-text`}>{option.type}</p>
               <p className={`${styles.cardPrice} body-text`}>KRW {option.price.toLocaleString()}</p>
             </div>
-          </button>
+          </a>
         ))}
       </div>
       <button

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -76,28 +76,33 @@ const TravelSection = () => {
       >
         <img src={chevronLeft} className={styles.navButtonIcon} alt="" />
       </button>
-      <div className={styles.carousel}>
+      <ul className={styles.carousel}>
         {travelOptions.map((option, index) => (
-          <a
+          <li
             key={index}
-            href={option.link}
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
-            aria-label={getAriaLabel(option)}
-            aria-live="polite"
-            target="_blank"
-            rel="noopener noreferrer"
           >
-            <img src={option.image} className={styles.cardImage} alt="" aria-hidden="true" />
-            <div className={styles.cardContent} aria-hidden="true">
-              <p className={`${styles.cardTitle} heading-3-text`}>
-                {option.departure} - {option.destination}
-              </p>
-              <p className={`${styles.cardType} body-text`}>{option.type}</p>
-              <p className={`${styles.cardPrice} body-text`}>KRW {option.price.toLocaleString()}</p>
-            </div>
-          </a>
+            <a
+              aria-label={getAriaLabel(option)}
+              aria-live="polite"
+              href={option.link}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <img src={option.image} className={styles.cardImage} alt="" />
+              <div className={styles.cardContent} aria-hidden="true">
+                <h3 className={`${styles.cardTitle} heading-3-text`}>
+                  {option.departure} - {option.destination}
+                </h3>
+                <p className={`${styles.cardType} body-text`}>{option.type}</p>
+                <p className={`${styles.cardPrice} body-text`}>
+                  KRW {option.price.toLocaleString()}
+                </p>
+              </div>
+            </a>
+          </li>
         ))}
-      </div>
+      </ul>
       <button
         type="button"
         aria-label="다음 여행 상품"

--- a/src/index.css
+++ b/src/index.css
@@ -113,6 +113,9 @@ button {
   padding: 0;
   color: #000;
 }
+a {
+  color: #000;
+}
 body {
   margin: 0;
   padding: 0;

--- a/src/index.css
+++ b/src/index.css
@@ -109,6 +109,8 @@ ul {
   list-style: none;
 }
 button {
+  margin: 0;
+  padding: 0;
   color: #000;
 }
 body {


### PR DESCRIPTION
안녕하세요 포메 🐶
레벨2 회고 수업 때 만나고 두 번째로 미션에서 만나게되네요 반갑습니다 😊
미션에서 가장 어려운 부분을 뽑자면 역시나 보이스 오버 사용이었네요.. 약간 환청 이슈도 생긴 것 같습니다..
미션 요구사항을 진행해 나가면서 "이렇게 하는게 맞나..?"라는 의문도 가득했던 것 같아요
일단 잘 부탁드립니다 👻

-----

## 🔥 결과

<!-- 개선 작업 후 모바일 낭독기를 사용해서 미션 페이지를 읽어보세요 -->
- 배포한 페이지 접근 경로(GitHub Pages): https://0jenn0.github.io/a11y-airline/
- 스크린 리더 화면 녹화 영상 (before / after)

| 컴포넌트 접근성 개선 | 바로가기 링크 적용 |
| --- | --- | 
| - [before 영상](https://github.com/user-attachments/assets/44914b28-901d-41ef-9710-c1190eb11042)<br>- [after 영상](https://github.com/user-attachments/assets/ef999ae3-cfce-4f04-9bfb-f38e8b17ae20) | - [before 영상](https://github.com/user-attachments/assets/f8a412e9-645c-49b1-a947-26dcf5520e0b)<br>- [after 영상](https://github.com/user-attachments/assets/9af58dca-7f82-4091-916f-06687ab8d3d2) | 

### Accessibility Insights for Web 

<table>
  <thead>
    <tr>
      <th>테스트 케이스</th>
      <th>before</th>
      <th>after</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>Landmarks</td>
      <td><img width="300" alt="스크린샷 2024-09-28 오후 8 37 22" src="https://github.com/user-attachments/assets/0aa873ef-a719-4cb5-8028-0ce419f8fe2d"></td>
      <td><img width="300" alt="스크린샷 2024-09-28 오후 8 32 05" src="https://github.com/user-attachments/assets/3930a301-ee88-4eae-9e42-7e8a18e53b70"></td>
    </tr>
    <tr>
      <td>Headings</td>
      <td><img width="300" alt="스크린샷 2024-09-28 오후 8 36 57" src="https://github.com/user-attachments/assets/40820acf-e1cb-4479-8f83-46512b06b1fb"></td>
      <td><img width="300" alt="스크린샷 2024-09-28 오후 8 29 31" src="https://github.com/user-attachments/assets/57aee14d-f89f-4e82-9d1c-92543375a8e2"></td>
    </tr>
    <tr>
      <td>Accessible names</td>
      <td><img width="300" alt="스크린샷 2024-09-28 오후 8 37 10" src="https://github.com/user-attachments/assets/bee8b62f-70ac-4722-8965-5d826fee8eb9"></td>
      <td><img width="300" alt="스크린샷 2024-09-28 오후 8 34 30" src="https://github.com/user-attachments/assets/ef6c253b-b16e-43ff-a40f-de37082d7be8"></td>
    </tr>
  </tbody>
</table>

### Accessibility Insights for Web - Needs review

**color-contrast 체크**

> Accessibility Insights for Web에서 이미지 캐로셀의 color-contrast 부분은 수동으로 확인해 달라고 요구하더라구요. 맥에서는 
[Colour Contrast Analyser (CCA)](https://developer.paciellogroup.com/color-contrast-checker/) 사용을 추천하길래 이 프로그램을 사용하여 color-contrast을 확인했습니다.
개선 전 확인 결과, 이미지에 적용되어있는 그라데이션 덕분에 모든 캐로셀에서 통과하여 이 부분에서는 따로 개선하지 않았습니다.

| 첫번째 캐로셀 | 두번째 캐로셀 | 세번째 캐로셀 |
| ---- | ---- | ---- |
| <img width="300" alt="스크린샷 2024-09-28 오후 8 50 05" src="https://github.com/user-attachments/assets/e6a6660e-9afc-46b0-9827-5ac5f7816362"> | <img width="300" alt="스크린샷 2024-09-28 오후 8 49 41" src="https://github.com/user-attachments/assets/f48928ad-3bf2-47e5-89c7-c8200ab420a6"> | <img width="300" alt="스크린샷 2024-09-28 오후 8 49 15" src="https://github.com/user-attachments/assets/b91fdee3-21c5-45e3-9370-ecfe8ddabe1f"> |


## ✅ 개선 작업 목록

<!-- 각 요구 사항을 위해 어떤 부분을 고민/학습해보았고, 결과적으로 어떤 개선 작업을 진행했는지 적어주세요-->

### 1. 헤딩 레벨(`<h1>` ~ `<h6>`)을 논리적 순서로 사용
  + 헤딩 레벨을 건너뛰지 않고 순차적으로 사용해야된다는 것을 새로 알게되었습니다. (예 : `<h1>` 다음에 `<h3>`을 사용 지양. 순차적으로 `<h2>`를 사용한다.)

### 2. 스크린 리더가 이미지 캐로셀 내 각 아이템 정보를 읽을 수 있게하기
+ 캐로셀 부분 `<button>` 태그 대신 `<a>` 태그를 사용했습니다. `<button>` 태그는 사용자의 보통 눌렀을 때 페이지 내에서 어떤 동작을 수행한다는 시맨틱 의미를 가지고있기 때문입니다. 누르면 예약 페이지로 이동하기 때문에 `<a>` 태그 사용이 더 적절하다고 생각했습니다. 다만  `<a>` 태그를 사용할 경우 보이스 오버에서 안의 요소들(출발 및 도착지, 가격 등등)이 개별 선택되는 문제가 있어 이 부분은 `aria-hidden="true"` 속성을 안에 요소들에게 주어 해결했습니다.
  

**1 컴포넌트 접근성 개선 - 이미지 캐로셀**

- [x] 스크린 리더가 캐로셀의 전체 아이템 수를 읽을 수 있어야 합니다. 
- [x] 스크린 리더가 이미지 캐로셀 내 각 아이템 정보를 읽을 수 있어야 합니다.
  - [x] 여행지, 좌석 유형, 가격 정보를 한번에 읽을 수 있어야 합니다.
  - [x] 이전/다음 아이템으로 이동하고 현재 보이는 아이템의 정보를 읽을 수 있어야 합니다.
- [x] 각 아이템을 선택하면 각각에 맞는 링크로 이동할 수 있어야 합니다.

**2 페이지 접근성 개선**

- [x] 페이지를 하나의 문서로 읽을 수 있어야 합니다.
  - [x] 페이지에 적절한 제목(title)을 제공하세요. 제목은 페이지의 주요 내용을 간결하게 설명해야 합니다.
  - [x] 페이지의 주요 영역을 시맨틱 태그를 사용해 명확히 구분해 주세요
  - [x] 헤딩을 논리적인 순서로 사용해 페이지 구조를 명확히 해주세요
- [x] 키보드 사용자를 위해 페이지 최상단에 '본문으로 바로가기' 링크를 제공해 반복되는 메뉴를 건너뛸 수 있게 해주세요

## 🧐 우리 팀의 접근성 체크리스트

<!--
우리 서비스에서 이런 부분의 접근성은 챙겨봐야겠다! 하는 체크리스트 v1을 만들고, 리뷰어와 의견을 나눠보세요-->

- 우리 팀 서비스에서 가장 중요하고 자주 사용되는 기능 플로우 1개를 선택하고 간단히 나열해 주세요 (예: 로그인 → 상품 검색 → 상품 선택 → 장바구니 추가 → 결제)
### [투룻 사이트](https://touroot.kr/)의 기능 플로우 : 
- 로그인 -> 메인 페이지에서 여행기 선택 -> 여행 계획으로 변환 -> 여행 계획 공유
- 해당 플로우의 각 단계에 대해 다음 질문을 생각해 보세요.
  - 1. 화면을 볼 수 없는 사용자가 이 단계를 완료할 수 있는가?
    - 불가능하다. 메인 페이지에서 카드 컴포넌트가 선택되지 않아 키보드로 들어갈 수가 없다.
  - 2. 이 단계에서 제공하는 정보나 지시 사항이 모든 사용자에게 명확한가?
    -  선택되지 않은 요소들도 있고 적절한 aria-label 등이 되어있지 않아 명확하지 않다.

- 질문에 대해 팀원들과 의견을 나눠본 것을 바탕으로, 우리 팀만의 접근성 체크리스트 v1을 만들고 리뷰어와 의견을 나눠보세요. (예: "모든 이미지에 적절한 대체 텍스트가 제공되는가?")

### 투룻 접근성 체크리스트 v1

**모든 페이지 공통 요소**
- [x] 헤더의 버튼 및 drawer를 건너 뛸 수 있도록 본문으로 바로가기 링크를 제공한다.
- [x] aria를 제공할 이미지와 아닌 이미지를 구별하여 적절히 정보를 제공한다.
- [x] 포커스되어야하는데 포커스되지 않는 요소가 있는지 확인한다.

**메인 페이지**
- [x] 카드 컴포넌트를 선택하게되면 안에 개별 요소로 타고 들어가지 않고 제목,작성자,태그,좋아요 수 정보를 aria를 통해 알 수 있어야된다.
- [x] 키보드 사용자는 키보드를 통해 정렬,필터를 선택할 수 있어야하고 현재 선택된 정렬,필터가 뭔지 알 수 있어야한다.

**여행 계획으로 변환**
- [x] 제목이 20자 제한으로되어있는데 20자보다 넘게 입력할 시 20자가 초과됐다는 사실을 알 수 있어야한다.
  **장소 검색**
  - [x]  장소 input에 포커스가 됐을 경우 그 밑에 tip 내용도 같이 음성으로 안내하도록 한다.
- [x] 장소 추가 후, 요소 포커스가 그 장소 아코디언의 할일 추가에 가있도록 한다. 

> 보이스 오버로 간략히 사용해보면서 적어본 내용입니다. 장소 추가 후 그전 페이지로 돌아갔을 때 스크린 리더가 추가된 장소 부분부터 시작하는게 아니라 처음 부분부터 시작하더라구요. 그래서 추가된 부분까지 다시 tab키 한참 이동하여 남은 부분들을 처리해야되는 상황입니다. 추가된 부분으로 포커스가 일단 가능한지도 알아봐야겠고, 가능하더라도 만약에 구현 코드가 길어진다면 그래도 해야되는지, 결국 웹 접근성을 어디까지 챙겨야되는지에 대해서 고민이 되네요 💭
