### PR TITLE
[항공사 웹사이트의 컴포넌트 접근성 높이기] 소파(차승하) 미션 제출합니다.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,15 +1,13 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>A11Y AIRLINE</title>
+  </head>
 
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>React App</title>
-</head>
-
-<body>
-  <div id="root"></div>
-  <script type="module" src="/src/main.tsx"></script>
-</body>
-
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
 </html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,13 @@ function App() {
           A11Y AIRLINE은 고객 여러분의 안전하고 쾌적한 여행을 위해 최선을 다하고 있습니다.
         </p>
       </header>
-      <section id="main-content" className={styles.main} tabIndex={0} ref={contentRef}>
+      <section
+        id="main-content"
+        className={styles.main}
+        tabIndex={0}
+        ref={contentRef}
+        aria-label="메인 콘텐츠"
+      >
         <div className={styles.flightBooking}>
           <FlightBooking />
         </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,7 @@
+import FlightBooking from './components/FlightBooking';
 import Navigation from './components/Navigation';
 import TravelSection from './components/TravelSection';
 import styles from './App.module.css';
-
-// import FlightBooking from './components/FlightBooking';
 
 // import PromotionModal from './components/PromotionModal';
 
@@ -10,24 +9,24 @@ function App() {
   return (
     <div className={styles.app}>
       <Navigation />
-      <div className={styles.header}>
-        {/* <h1 className={`${styles.title} heading-1-text`}>A11Y AIRLINE</h1>
+      <header className={styles.header}>
+        <h1 className={`${styles.title} heading-1-text`}>A11Y AIRLINE</h1>
         <p className="body-text">
           A11Y AIRLINE은 고객 여러분의 안전하고 쾌적한 여행을 위해 최선을 다하고 있습니다.
         </p>
-      </div>
-      <div id="main-content" className={styles.main}>
+      </header>
+      <section id="main-content" className={styles.main}>
         <div className={styles.flightBooking}>
           <FlightBooking />
-        </div> */}
+        </div>
         <div className={styles.travelSection}>
-          <h1 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h1>
+          <h2 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h2>
           <TravelSection />
         </div>
-      </div>
-      <div className={styles.footer}>
+      </section>
+      <footer className={styles.footer}>
         <p className="body-text">&copy; A11Y AIRLINE</p>
-      </div>
+      </footer>
       {/* 추가 CHALLENGE: 모달 포커스 트랩 */}
       {/* <PromotionModal /> */}
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,9 @@
-import styles from './App.module.css';
 import Navigation from './components/Navigation';
-import FlightBooking from './components/FlightBooking';
 import TravelSection from './components/TravelSection';
+import styles from './App.module.css';
+
+// import FlightBooking from './components/FlightBooking';
+
 // import PromotionModal from './components/PromotionModal';
 
 function App() {
@@ -9,7 +11,7 @@ function App() {
     <div className={styles.app}>
       <Navigation />
       <div className={styles.header}>
-        <h1 className={`${styles.title} heading-1-text`}>A11Y AIRLINE</h1>
+        {/* <h1 className={`${styles.title} heading-1-text`}>A11Y AIRLINE</h1>
         <p className="body-text">
           A11Y AIRLINE은 고객 여러분의 안전하고 쾌적한 여행을 위해 최선을 다하고 있습니다.
         </p>
@@ -17,7 +19,7 @@ function App() {
       <div id="main-content" className={styles.main}>
         <div className={styles.flightBooking}>
           <FlightBooking />
-        </div>
+        </div> */}
         <div className={styles.travelSection}>
           <h1 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h1>
           <TravelSection />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,20 +2,22 @@ import FlightBooking from './components/FlightBooking';
 import Navigation from './components/Navigation';
 import TravelSection from './components/TravelSection';
 import styles from './App.module.css';
+import { useRef } from 'react';
 
 // import PromotionModal from './components/PromotionModal';
 
 function App() {
+  const contentRef = useRef<HTMLElement>(null);
   return (
     <div className={styles.app}>
-      <Navigation />
+      <Navigation contentRef={contentRef} />
       <header className={styles.header}>
         <h1 className={`${styles.title} heading-1-text`}>A11Y AIRLINE</h1>
         <p className="body-text">
           A11Y AIRLINE은 고객 여러분의 안전하고 쾌적한 여행을 위해 최선을 다하고 있습니다.
         </p>
       </header>
-      <section id="main-content" className={styles.main}>
+      <section id="main-content" className={styles.main} tabIndex={0} ref={contentRef}>
         <div className={styles.flightBooking}>
           <FlightBooking />
         </div>

--- a/src/components/FlightBooking.tsx
+++ b/src/components/FlightBooking.tsx
@@ -1,9 +1,8 @@
 import { useCallback, useState } from 'react';
 
 import helpIcon from '../assets/help.svg';
-import plus from '../assets/plus.svg';
 import minus from '../assets/minus.svg';
-
+import plus from '../assets/plus.svg';
 import styles from './FlightBooking.module.css';
 
 const MIN_PASSENGERS = 1;
@@ -51,11 +50,11 @@ const FlightBooking = () => {
         </div>
         <div className={styles.counter}>
           <button className="button-text" onClick={decrementCount} aria-label="성인 승객 감소">
-            <img src={minus} alt="" />
+            <img src={minus} alt="감소" />
           </button>
           <span aria-live="polite">{adultCount}</span>
           <button className="button-text" onClick={incrementCount} aria-label="성인 승객 증가">
-            <img src={plus} alt="" />
+            <img src={plus} alt="추가" />
           </button>
         </div>
       </div>

--- a/src/components/FlightBooking.tsx
+++ b/src/components/FlightBooking.tsx
@@ -16,6 +16,7 @@ const FlightBooking = () => {
   const incrementCount = useCallback(() => {
     if (adultCount === MAX_PASSENGERS) {
       setStatusMessage('최대 승객 수에 도달했습니다');
+      setTimeout(() => setStatusMessage(''), 500);
       return;
     }
 
@@ -26,6 +27,7 @@ const FlightBooking = () => {
   const decrementCount = useCallback(() => {
     if (adultCount === MIN_PASSENGERS) {
       setStatusMessage('최소 1명의 승객이 필요합니다');
+      setTimeout(() => setStatusMessage(''), 500);
       return;
     }
 

--- a/src/components/Navigation.module.css
+++ b/src/components/Navigation.module.css
@@ -1,53 +1,53 @@
 .mainNav {
   background-color: #f8f8f8;
-  padding: 10px 0;
+  padding         : 10px 0;
 }
 
 .navList {
   list-style-type: none;
-  padding: 10px 16px;
-  margin: 0;
+  padding        : 10px 16px;
+  margin         : 0;
 }
 
 .navItem {
-  display: inline-block;
-  position: relative;
+  display     : inline-block;
+  position    : relative;
   margin-right: 20px;
 }
 
 .navItem a {
   text-decoration: none;
-  color: #333;
-  font-size: 16px;
-  padding: 5px 10px;
-  display: block;
+  color          : #333;
+  font-size      : 16px;
+  padding        : 5px 10px;
+  display        : block;
 }
 
 .navItem a:hover,
 .navItem a:focus {
   background-color: #e0e0e0;
-  border-radius: 4px;
+  border-radius   : 4px;
 }
 
 .navItem .navList {
-  display: none;
-  position: absolute;
-  top: 100%;
-  left: 0;
+  display         : none;
+  position        : absolute;
+  top             : 100%;
+  left            : 0;
   background-color: #fff;
-  border: 1px solid #ddd;
-  border-radius: 4px;
-  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+  border          : 1px solid #ddd;
+  border-radius   : 4px;
+  box-shadow      : 0 2px 5px rgba(0, 0, 0, 0.1);
 }
 
-.navItem:hover > .navList,
-.navItem:focus-within > .navList {
+.navItem:hover>.navList,
+.navItem:focus-within>.navList {
   display: block;
 }
 
 .navItem .navList .navItem {
-  width: 200px;
-  display: block;
+  width       : 200px;
+  display     : block;
   margin-right: 0;
 }
 
@@ -61,15 +61,33 @@
 }
 
 .navToggle {
-  display: none;
-  font-size: 16px;
-  padding: 10px;
+  display         : none;
+  font-size       : 16px;
+  padding         : 10px;
   background-color: #333;
-  color: white;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
+  color           : white;
+  border          : none;
+  border-radius   : 4px;
+  cursor          : pointer;
 }
+
+.skipNav {
+  position   : absolute;
+  top        : -30px;
+  left       : 0;
+  background : #000;
+  height     : 30px;
+  line-height: 30px;
+  color      : #fff;
+  font-size  : 12px;
+  padding    : 0 6px;
+}
+
+.skipNav:focus,
+.skipNav:active {
+  top: 0;
+}
+
 
 @media (max-width: 768px) {
   .navToggle {
@@ -85,22 +103,22 @@
   }
 
   .navItem {
-    display: block;
-    margin-right: 0;
+    display      : block;
+    margin-right : 0;
     margin-bottom: 10px;
   }
 
   .navItem .navList {
-    position: static;
-    display: none;
-    width: auto;
-    border: none;
-    box-shadow: none;
+    position   : static;
+    display    : none;
+    width      : auto;
+    border     : none;
+    box-shadow : none;
     margin-left: 20px;
   }
 
-  .navItem:hover > .navList,
-  .navItem:focus-within > .navList {
+  .navItem:hover>.navList,
+  .navItem:focus-within>.navList {
     display: block;
   }
 

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
 import styles from './Navigation.module.css';
+import { useState } from 'react';
 
 interface NavItem {
   title: string;
@@ -37,8 +37,12 @@ const navItems: NavItem[] = [
   { title: '고객 지원', link: '#' }
 ];
 
-const Navigation = () => {
+const Navigation = ({ contentRef }: { contentRef?: React.RefObject<HTMLElement> }) => {
   const [isNavOpen, setIsNavOpen] = useState(false);
+
+  const skipNavigationClickHandler = () => {
+    contentRef?.current?.focus();
+  };
 
   const toggleNav = () => {
     setIsNavOpen((prev) => !prev);
@@ -57,6 +61,9 @@ const Navigation = () => {
 
   return (
     <>
+      <button tabIndex={1} onClick={skipNavigationClickHandler} className={styles.skipNav}>
+        콘텐츠로 이동하기
+      </button>
       <button className={styles.navToggle} onClick={toggleNav}>
         {isNavOpen ? '닫기' : '메뉴'}
       </button>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -61,7 +61,7 @@ const Navigation = ({ contentRef }: { contentRef?: React.RefObject<HTMLElement> 
 
   return (
     <>
-      <button tabIndex={1} onClick={skipNavigationClickHandler} className={styles.skipNav}>
+      <button tabIndex={0} onClick={skipNavigationClickHandler} className={styles.skipNav}>
         콘텐츠로 이동하기
       </button>
       <button className={styles.navToggle} onClick={toggleNav}>

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -47,9 +47,9 @@ const TravelSection = () => {
   const [currentIndex, setCurrentIndex] = useState(0);
 
   // 접근성을 위한 ref
-  const ariaRef1 = useRef<HTMLDivElement>(null);
-  const ariaRef2 = useRef<HTMLDivElement>(null);
-  const ariaRef3 = useRef<HTMLDivElement>(null);
+  const ariaRef1 = useRef<HTMLLIElement>(null);
+  const ariaRef2 = useRef<HTMLLIElement>(null);
+  const ariaRef3 = useRef<HTMLLIElement>(null);
   const ariaRefs = useMemo(() => [ariaRef1, ariaRef2, ariaRef3], []);
   const [isFirstRender, setIsFirstRender] = useState(true);
 
@@ -81,14 +81,16 @@ const TravelSection = () => {
       <button className={`${styles.navButton} ${styles.navButtonPrev}`} onClick={prevTravel}>
         <img src={chevronLeft} className={styles.navButtonIcon} aria-label="이전 옵션" />
       </button>
-      <div className={styles.carousel}>
+      <ul className={styles.carousel}>
         {travelOptions.map((option, index) => (
-          <div
+          <li
             key={index}
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
             onMouseUp={() => handleCardClick(option.link)}
             aria-label={
-              `여행 포커스 됨 ${option.departure}에서 ${option.destination} ${option.type} ${option.price}원` +
+              `여행 포커스 됨 옵션 ${travelOptions.length}개 중 ${index + 1}번째 옵션 ${
+                option.departure
+              }에서 ${option.destination} ${option.type} ${option.price}원` +
               ' 클릭 시 해당 페이지로 이동합니다'
             }
             ref={ariaRefs[index]}
@@ -107,9 +109,9 @@ const TravelSection = () => {
                 KRW {option.price.toLocaleString()}
               </p>
             </div>
-          </div>
+          </li>
         ))}
-      </div>
+      </ul>
       <button
         className={`${styles.navButton} ${styles.navButtonNext}`}
         onClick={nextTravel}

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -79,7 +79,12 @@ const TravelSection = () => {
   return (
     <div className={styles.travelSection}>
       <button className={`${styles.navButton} ${styles.navButtonPrev}`} onClick={prevTravel}>
-        <img src={chevronLeft} className={styles.navButtonIcon} aria-label="이전 옵션" />
+        <img
+          src={chevronLeft}
+          className={styles.navButtonIcon}
+          aria-label="이전 옵션"
+          alt="이전 옵션"
+        />
       </button>
       <ul className={styles.carousel}>
         {travelOptions.map((option, index) => (
@@ -97,7 +102,12 @@ const TravelSection = () => {
             // 접근성을 위한 tabIndex
             tabIndex={0}
           >
-            <img src={option.image} className={styles.cardImage} aria-hidden />
+            <img
+              src={option.image}
+              alt={option.destination + ' 소개 이미지'}
+              className={styles.cardImage}
+              aria-hidden
+            />
             <div className={styles.cardContent} aria-hidden>
               <p className={`${styles.cardTitle} heading-3-text`} aria-hidden>
                 {option.departure} - {option.destination}
@@ -117,7 +127,7 @@ const TravelSection = () => {
         onClick={nextTravel}
         aria-label="다음 옵션"
       >
-        <img src={chevronRight} className={styles.navButtonIcon} />
+        <img src={chevronRight} alt="다음 옵션" className={styles.navButtonIcon} />
       </button>
     </div>
   );

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -60,7 +60,7 @@ const TravelSection = () => {
   return (
     <div className={styles.travelSection}>
       <button className={`${styles.navButton} ${styles.navButtonPrev}`} onClick={prevTravel}>
-        <img src={chevronLeft} className={styles.navButtonIcon} />
+        <img src={chevronLeft} className={styles.navButtonIcon} aria-label="이전 옵션" />
       </button>
       <div className={styles.carousel}>
         {travelOptions.map((option, index) => (
@@ -68,12 +68,9 @@ const TravelSection = () => {
             key={index}
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
             onClick={() => handleCardClick(option.link)}
+            aria-label={`${option.departure}에서 ${option.destination} ${option.type} ${option.price}원`}
           >
-            <img
-              src={option.image}
-              className={styles.cardImage}
-              aria-label={`${option.departure}에서 ${option.destination} ${option.type} ${option.price}원`}
-            />
+            <img src={option.image} className={styles.cardImage} aria-hidden />
             <div className={styles.cardContent} aria-hidden>
               <p className={`${styles.cardTitle} heading-3-text`} aria-hidden>
                 {option.departure} - {option.destination}
@@ -88,7 +85,11 @@ const TravelSection = () => {
           </div>
         ))}
       </div>
-      <button className={`${styles.navButton} ${styles.navButtonNext}`} onClick={nextTravel}>
+      <button
+        className={`${styles.navButton} ${styles.navButtonNext}`}
+        onClick={nextTravel}
+        aria-label="다음 옵션"
+      >
         <img src={chevronRight} className={styles.navButtonIcon} />
       </button>
     </div>

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -1,10 +1,11 @@
+import { MouseEvent, useEffect, useMemo, useRef, useState } from 'react';
+
 import chevronLeft from '../assets/chevron-left.svg';
 import chevronRight from '../assets/chevron-right.svg';
 import styles from './TravelSection.module.css';
 import travelItem01 from '../assets/travel-item-01.png';
 import travelItem02 from '../assets/travel-item-02.png';
 import travelItem03 from '../assets/travel-item-03.png';
-import { useState } from 'react';
 
 interface TravelOption {
   departure: string;
@@ -44,9 +45,16 @@ const travelOptions: TravelOption[] = [
 
 const TravelSection = () => {
   const [currentIndex, setCurrentIndex] = useState(0);
+  const ariaRef1 = useRef<HTMLDivElement>(null);
+  const ariaRef2 = useRef<HTMLDivElement>(null);
+  const ariaRef3 = useRef<HTMLDivElement>(null);
+  const ariaRefs = useMemo(() => [ariaRef1, ariaRef2, ariaRef3], []);
+  const [isFirstRender, setIsFirstRender] = useState(true);
 
-  const nextTravel = () => {
+  const nextTravel = (e: MouseEvent<HTMLButtonElement>) => {
     setCurrentIndex((prevIndex) => (prevIndex + 1) % travelOptions.length);
+    e.currentTarget.tabIndex = -1;
+    e.currentTarget.blur();
   };
 
   const prevTravel = () => {
@@ -56,6 +64,14 @@ const TravelSection = () => {
   const handleCardClick = (link: string) => {
     window.open(link, '_blank', 'noopener,noreferrer');
   };
+
+  useEffect(() => {
+    if (isFirstRender) {
+      setIsFirstRender(false);
+      return;
+    }
+    ariaRefs[currentIndex].current?.focus();
+  }, [currentIndex, ariaRefs]);
 
   return (
     <div className={styles.travelSection}>
@@ -67,8 +83,13 @@ const TravelSection = () => {
           <div
             key={index}
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
-            onClick={() => handleCardClick(option.link)}
-            aria-label={`${option.departure}에서 ${option.destination} ${option.type} ${option.price}원`}
+            onMouseUp={() => handleCardClick(option.link)}
+            aria-label={
+              `여행 포커스 됨 ${option.departure}에서 ${option.destination} ${option.type} ${option.price}원` +
+              ' 클릭 시 해당 페이지로 이동합니다'
+            }
+            ref={ariaRefs[index]}
+            tabIndex={1}
           >
             <img src={option.image} className={styles.cardImage} aria-hidden />
             <div className={styles.cardContent} aria-hidden>

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -95,7 +95,7 @@ const TravelSection = () => {
             }
             ref={ariaRefs[index]}
             // 접근성을 위한 tabIndex
-            tabIndex={1}
+            tabIndex={0}
           >
             <img src={option.image} className={styles.cardImage} aria-hidden />
             <div className={styles.cardContent} aria-hidden>

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -1,12 +1,10 @@
-import { useState } from 'react';
-
+import chevronLeft from '../assets/chevron-left.svg';
+import chevronRight from '../assets/chevron-right.svg';
+import styles from './TravelSection.module.css';
 import travelItem01 from '../assets/travel-item-01.png';
 import travelItem02 from '../assets/travel-item-02.png';
 import travelItem03 from '../assets/travel-item-03.png';
-import chevronLeft from '../assets/chevron-left.svg';
-import chevronRight from '../assets/chevron-right.svg';
-
-import styles from './TravelSection.module.css';
+import { useState } from 'react';
 
 interface TravelOption {
   departure: string;
@@ -71,13 +69,21 @@ const TravelSection = () => {
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
             onClick={() => handleCardClick(option.link)}
           >
-            <img src={option.image} className={styles.cardImage} />
-            <div className={styles.cardContent}>
-              <p className={`${styles.cardTitle} heading-3-text`}>
+            <img
+              src={option.image}
+              className={styles.cardImage}
+              aria-label={`${option.departure}에서 ${option.destination} ${option.type} ${option.price}원`}
+            />
+            <div className={styles.cardContent} aria-hidden>
+              <p className={`${styles.cardTitle} heading-3-text`} aria-hidden>
                 {option.departure} - {option.destination}
               </p>
-              <p className={`${styles.cardType} body-text`}>{option.type}</p>
-              <p className={`${styles.cardPrice} body-text`}>KRW {option.price.toLocaleString()}</p>
+              <p className={`${styles.cardType} body-text`} aria-hidden>
+                {option.type}
+              </p>
+              <p className={`${styles.cardPrice} body-text`} aria-hidden>
+                KRW {option.price.toLocaleString()}
+              </p>
             </div>
           </div>
         ))}

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -45,6 +45,8 @@ const travelOptions: TravelOption[] = [
 
 const TravelSection = () => {
   const [currentIndex, setCurrentIndex] = useState(0);
+
+  // 접근성을 위한 ref
   const ariaRef1 = useRef<HTMLDivElement>(null);
   const ariaRef2 = useRef<HTMLDivElement>(null);
   const ariaRef3 = useRef<HTMLDivElement>(null);
@@ -65,6 +67,7 @@ const TravelSection = () => {
     window.open(link, '_blank', 'noopener,noreferrer');
   };
 
+  // 접근성을 위한 useEffect
   useEffect(() => {
     if (isFirstRender) {
       setIsFirstRender(false);
@@ -89,6 +92,7 @@ const TravelSection = () => {
               ' 클릭 시 해당 페이지로 이동합니다'
             }
             ref={ariaRefs[index]}
+            // 접근성을 위한 tabIndex
             tabIndex={1}
           >
             <img src={option.image} className={styles.cardImage} aria-hidden />

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -109,9 +109,9 @@ const TravelSection = () => {
               aria-hidden
             />
             <div className={styles.cardContent} aria-hidden>
-              <p className={`${styles.cardTitle} heading-3-text`} aria-hidden>
+              <h3 className={`${styles.cardTitle} heading-3-text`} aria-hidden>
                 {option.departure} - {option.destination}
-              </p>
+              </h3>
               <p className={`${styles.cardType} body-text`} aria-hidden>
                 {option.type}
               </p>


### PR DESCRIPTION
안녕하세요 텐텐~ 반갑습니다~

미션시작을 너무 일찍 눌러버려서 filechange가 너무 많아졌네요ㅜㅜ
커밋위주로 봐주시면 감사드리겠습니다..!
그럼 잘부탁드려요!!

## 🔥 결과
![image](https://github.com/user-attachments/assets/a4d79c63-aa94-4822-a296-22df1520ca84)


<!-- 개선 작업 후 모바일 낭독기를 사용해서 미션 페이지를 읽어보세요 -->

- 배포한 페이지 접근 경로(GitHub): https://ss0526100.github.io/a11y-airline/
- 스크린 리더 화면 녹화 영상 (before / after)
before는 별도로 첨부하지 않았습니다!


https://github.com/user-attachments/assets/ba72d894-619c-4290-810d-379e76b75d3f


## ✅ 개선 작업 목록

<!-- 각 요구 사항을 위해 어떤 부분을 고민/학습해보았고, 결과적으로 어떤 개선 작업을 진행했는지 적어주세요-->

**1 컴포넌트 접근성 개선 - 이미지 캐로셀**

- [x] 스크린 리더가 캐로셀의 전체 아이템 수를 읽을 수 있어야 합니다.
- [x] 스크린 리더가 이미지 캐로셀 내 각 아이템 정보를 읽을 수 있어야 합니다.
  - [x] 여행지, 좌석 유형, 가격 정보를 한번에 읽을 수 있어야 합니다.
  - [x] 이전/다음 아이템으로 이동하고 현재 보이는 아이템의 정보를 읽을 수 있어야 합니다.
  ```
     `여행 포커스 됨 옵션 ${travelOptions.length}개 중 ${index + 1}번째 옵션 ${
                option.departure
              }에서 ${option.destination} ${option.type} ${option.price}원` +
              ' 클릭 시 해당 페이지로 이동합니다'
  ```
다음과 같이 문구를 `travelOptions` 전체에 적용시키고 내부의 값에는 aria-hidden을 주었습니다.

- [x] 각 아이템을 선택하면 각각에 맞는 링크로 이동할 수 있어야 합니다.

**2 페이지 접근성 개선**

- [x] 페이지를 하나의 문서로 읽을 수 있어야 합니다.
  - [x] 페이지에 적절한 제목(title)을 제공하세요. 제목은 페이지의 주요 내용을 간결하게 설명해야 합니다.
  - [x] 페이지의 주요 영역을 시맨틱 태그를 사용해 명확히 구분해 주세요
  - [x] 헤딩을 논리적인 순서로 사용해 페이지 구조를 명확히 해주세요
- [x] 키보드 사용자를 위해 페이지 최상단에 '본문으로 바로가기' 링크를 제공해 반복되는 메뉴를 건너뛸 수 있게 해주세요

## 🧐 우리 팀의 접근성 체크리스트

로그인->다락방(워크스페이스)선택->모임 목록 페이지->모임 목록 상세 페이지->참여

이 중에서 핵심 중의 핵심은
`모임 목록 상세 페이지`
라고 생각합니다.
![image](https://github.com/user-attachments/assets/6a0c287c-87d8-4f30-ba20-09126a5e0bdf)

모임 목록 상세 페이지의 체크리스트를 짜보자면
- [ ] 뒤로가기 버튼 aria-label 주기
- [ ] 모임 제목과 상태 aria label주기
- [ ] 찜버튼(하트) 토글 버튼으로 관리하기
- [ ] 모임 수정/취소 등 모임 관리 section aria-role 주기
- [ ] 참여자 리스트 aria-label관리
- [ ] 모임정보/상세설명 같이 aria-label로 관리하기
- [ ] 코멘트보내기 index 잘 주기
- [ ] 모집완료/참여 footer 버튼 aria-role 주기
정도가 될 것 같습니다!

그러면 잘부탁드려요!