### PR TITLE
[항공사 웹사이트의 컴포넌트 접근성 높이기] 올리(이예진) 미션 제출합니다.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>A11Y 항공 좌석 예매</title>
+    <title>A11Y 항공</title>
   </head>
 
   <body>

--- a/index.html
+++ b/index.html
@@ -1,15 +1,13 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>a11y 항공 좌석 예매</title>
+  </head>
 
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>React App</title>
-</head>
-
-<body>
-  <div id="root"></div>
-  <script type="module" src="/src/main.tsx"></script>
-</body>
-
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>a11y 항공 좌석 예매</title>
+    <title>A11Y 항공 좌석 예매</title>
   </head>
 
   <body>

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "deploy": "npm run build && npx gh-pages -d dist"
   },
   "author": "woowacourse",
-  "homepage": "https://{imxyjl}.github.io/a11y-airline",
+  "homepage": "https://imxyjl.github.io/a11y-airline",
   "license": "MIT",
   "dependencies": {
     "react": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "deploy": "npm run build && npx gh-pages -d dist"
   },
   "author": "woowacourse",
-  "homepage": "https://{username}.github.io/a11y-airline",
+  "homepage": "https://{imxyjl}.github.io/a11y-airline",
   "license": "MIT",
   "dependencies": {
     "react": "^18.3.1",

--- a/src/App.module.css
+++ b/src/App.module.css
@@ -9,6 +9,11 @@
   margin: 0 auto;
 }
 
+.content:focus {
+  color: black;
+  border-radius: 2px;
+}
+
 .header {
   padding: 48px 24px 24px 24px;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,24 +8,24 @@ function App() {
   return (
     <div className={styles.app}>
       <Navigation />
-      <div className={styles.header}>
+      <header className={styles.header}>
         <h1 className={`${styles.title} heading-1-text`}>A11Y AIRLINE</h1>
         <p className="body-text">
           A11Y AIRLINE은 고객 여러분의 안전하고 쾌적한 여행을 위해 최선을 다하고 있습니다.
         </p>
-      </div>
-      <div id="main-content" className={styles.main}>
-        <div className={styles.flightBooking}>
+      </header>
+      <main id="main-content" className={styles.main}>
+        <section className={styles.flightBooking}>
           <FlightBooking />
-        </div>
-        <div className={styles.travelSection}>
-          <h1 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h1>
+        </section>
+        <section className={styles.travelSection}>
+          <h2 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h2>
           <TravelSection />
-        </div>
-      </div>
-      <div className={styles.footer}>
+        </section>
+      </main>
+      <footer className={styles.footer}>
         <p className="body-text">&copy; A11Y AIRLINE</p>
-      </div>
+      </footer>
       {/* 추가 CHALLENGE: 모달 포커스 트랩 */}
       {/* <PromotionModal /> */}
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,27 +2,55 @@ import styles from './App.module.css';
 import Navigation from './components/Navigation';
 import FlightBooking from './components/FlightBooking';
 import TravelSection from './components/TravelSection';
+import SkipToContent from './components/SkipToContent';
+import { useRef } from 'react';
 // import PromotionModal from './components/PromotionModal';
 
 function App() {
+  const headerId = 'header';
+  const contentRef = useRef<HTMLElement>(null);
+
+  const handleSkipClick = (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
+    e.preventDefault();
+    if (contentRef.current) {
+      contentRef.current.focus();
+      contentRef.current.scrollIntoView({ behavior: 'smooth' });
+    }
+  };
+
+  const handleSkipKeyDown = (e: React.KeyboardEvent<HTMLAnchorElement>) => {
+    if (e.key === 'Enter' && contentRef.current) {
+      e.preventDefault();
+      contentRef.current.focus();
+      contentRef.current.scrollIntoView({ behavior: 'smooth' });
+    }
+  };
+
   return (
     <div className={styles.app}>
+      <SkipToContent
+        hrefString={`#${headerId}`}
+        handleOnClick={handleSkipClick}
+        handleOnKeyDown={handleSkipKeyDown}
+      />
       <Navigation />
-      <header className={styles.header}>
-        <h1 className={`${styles.title} heading-1-text`}>A11Y AIRLINE</h1>
-        <p className="body-text">
-          A11Y AIRLINE은 고객 여러분의 안전하고 쾌적한 여행을 위해 최선을 다하고 있습니다.
-        </p>
-      </header>
-      <main id="main-content" className={styles.main}>
-        <section className={styles.flightBooking}>
-          <FlightBooking />
-        </section>
-        <section className={styles.travelSection}>
-          <h2 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h2>
-          <TravelSection />
-        </section>
-      </main>
+      <section id="a11y-airline-content" className={styles.content} ref={contentRef} tabIndex={-1}>
+        <header id={headerId} className={styles.header}>
+          <h1 className={`${styles.title} heading-1-text`}>A11Y AIRLINE</h1>
+          <p className="body-text">
+            A11Y AIRLINE은 고객 여러분의 안전하고 쾌적한 여행을 위해 최선을 다하고 있습니다.
+          </p>
+        </header>
+        <main id="main-content" className={styles.main}>
+          <section className={styles.flightBooking}>
+            <FlightBooking />
+          </section>
+          <section className={styles.travelSection}>
+            <h2 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h2>
+            <TravelSection />
+          </section>
+        </main>
+      </section>
       <footer className={styles.footer}>
         <p className="body-text">&copy; A11Y AIRLINE</p>
       </footer>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,7 +34,7 @@ function App() {
         handleOnKeyDown={handleSkipKeyDown}
       />
       <Navigation />
-      <section id="a11y-airline-content" className={styles.content} ref={contentRef} tabIndex={-1}>
+      <section id="a11y-airline-content" className={styles.content} ref={contentRef}>
         <header id={headerId} className={styles.header}>
           <h1 className={`${styles.title} heading-1-text`}>A11Y AIRLINE</h1>
           <p className="body-text">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,7 +34,7 @@ function App() {
         handleOnKeyDown={handleSkipKeyDown}
       />
       <Navigation />
-      <section id="a11y-airline-content" className={styles.content} ref={contentRef}>
+      <section id="a11y-airline-content" className={styles.content} ref={contentRef} tabIndex={0}>
         <header id={headerId} className={styles.header}>
           <h1 className={`${styles.title} heading-1-text`}>A11Y AIRLINE</h1>
           <p className="body-text">

--- a/src/components/FlightBooking.tsx
+++ b/src/components/FlightBooking.tsx
@@ -35,7 +35,7 @@ const FlightBooking = () => {
   }, [adultCount]);
 
   return (
-    <div className={styles.flightBooking}>
+    <article className={styles.flightBooking}>
       <h2 className="heading-2-text">항공권 예매</h2>
       <div className={styles.passengerCount}>
         <div className={styles.passengerLabel}>
@@ -65,7 +65,7 @@ const FlightBooking = () => {
         </div>
       )}
       <button className={styles.searchButton}>항공편 검색</button>
-    </div>
+    </article>
   );
 };
 

--- a/src/components/FlightBooking.tsx
+++ b/src/components/FlightBooking.tsx
@@ -53,7 +53,9 @@ const FlightBooking = () => {
           <button className="button-text" onClick={decrementCount} aria-label="성인 승객 감소">
             <img src={minus} alt="" />
           </button>
-          <span aria-live="polite">{adultCount}</span>
+          <span aria-live="polite" aria-label={`현재 성인 ${adultCount}명`}>
+            {adultCount}
+          </span>
           <button className="button-text" onClick={incrementCount} aria-label="성인 승객 증가">
             <img src={plus} alt="" />
           </button>

--- a/src/components/Navigation.module.css
+++ b/src/components/Navigation.module.css
@@ -40,8 +40,8 @@
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
 }
 
-.navItem:hover > .navList,
-.navItem:focus-within > .navList {
+.navItem:hover .navList,
+.navItem:focus-within .navList {
   display: block;
 }
 

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -49,7 +49,11 @@ const Navigation = () => {
       {items.map((item, index) => (
         <li key={index} className={styles.navItem}>
           <a href={item.link}>{item.title}</a>
-          {item.subItems && renderNavItems(item.subItems)}
+          {item.subItems && (
+            <nav aria-label={`${item.title} 상세`} className={styles.subNav}>
+              {renderNavItems(item.subItems)}
+            </nav>
+          )}
         </li>
       ))}
     </ul>
@@ -60,7 +64,11 @@ const Navigation = () => {
       <button className={styles.navToggle} onClick={toggleNav}>
         {isNavOpen ? '닫기' : '메뉴'}
       </button>
-      <nav id="main-nav" className={`${styles.mainNav} ${isNavOpen ? styles.mainNavActive : ''}`}>
+      <nav
+        id="main-nav"
+        className={`${styles.mainNav} ${isNavOpen ? styles.mainNavActive : ''}`}
+        aria-label="주요 메뉴"
+      >
         {renderNavItems(navItems)}
       </nav>
     </>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -49,11 +49,7 @@ const Navigation = () => {
       {items.map((item, index) => (
         <li key={index} className={styles.navItem}>
           <a href={item.link}>{item.title}</a>
-          {item.subItems && (
-            <nav aria-label={`${item.title} 상세`} className={styles.subNav}>
-              {renderNavItems(item.subItems)}
-            </nav>
-          )}
+          {item.subItems && <nav className={styles.subNav}>{renderNavItems(item.subItems)}</nav>}
         </li>
       ))}
     </ul>

--- a/src/components/SkipToContent.module.css
+++ b/src/components/SkipToContent.module.css
@@ -1,16 +1,15 @@
 .skipLink {
-  display: block;
   position: absolute;
-  top: -100px;
+  top: 0;
   left: 0;
-  padding: 0;
+  padding: 18px 16px;
   background-color: #000;
   color: #fff;
   z-index: 100;
-  transition: top 0.3s, padding 0.3s;
+  transform: translateY(-100%);
+  transition: transform 0.3s;
 }
 
 .skipLink:focus {
-  top: 0;
-  padding: 18px 16px;
+  transform: translateY(0);
 }

--- a/src/components/SkipToContent.module.css
+++ b/src/components/SkipToContent.module.css
@@ -1,0 +1,16 @@
+.skipLink {
+  display: block;
+  position: absolute;
+  top: -100px;
+  left: 0;
+  padding: 0;
+  background-color: #000;
+  color: #fff;
+  z-index: 100;
+  transition: top 0.3s, padding 0.3s;
+}
+
+.skipLink:focus {
+  top: 0;
+  padding: 18px 16px;
+}

--- a/src/components/SkipToContent.tsx
+++ b/src/components/SkipToContent.tsx
@@ -1,0 +1,21 @@
+import styles from './SkipToContent.module.css';
+interface SkipToContentProps {
+  hrefString: string;
+  handleOnClick: (e: React.MouseEvent<HTMLAnchorElement>) => void;
+  handleOnKeyDown: (e: React.KeyboardEvent<HTMLAnchorElement>) => void;
+}
+
+const SkipToContent = ({ hrefString, handleOnClick, handleOnKeyDown }: SkipToContentProps) => {
+  return (
+    <a
+      href={hrefString}
+      className={styles.skipLink}
+      onClick={handleOnClick}
+      onKeyDown={handleOnKeyDown}
+    >
+      본문으로 넘어가기
+    </a>
+  );
+};
+
+export default SkipToContent;

--- a/src/components/TravelSection.module.css
+++ b/src/components/TravelSection.module.css
@@ -23,6 +23,10 @@
   display: block;
 }
 
+.cardActive:hover {
+  cursor: pointer;
+}
+
 .cardImage {
   width: 100%;
   height: 100%;

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -55,34 +55,63 @@ const TravelSection = () => {
     setCurrentIndex((prevIndex) => (prevIndex - 1 + travelOptions.length) % travelOptions.length);
   };
 
+  const getParsedCityName = (fullString: string) => {
+    return `${fullString.includes('/') ? fullString.replace('/', '슬래시') : fullString}`;
+  };
+
+  const handleKeyPress = (e: React.KeyboardEvent<HTMLLIElement>, link: string) => {
+    if (e.key === 'Enter') handleCardClick(link);
+  };
+
   const handleCardClick = (link: string) => {
     window.open(link, '_blank', 'noopener,noreferrer');
   };
 
   return (
-    <div className={styles.travelSection}>
+    <div className={styles.travelSection} role="carousel">
       <button className={`${styles.navButton} ${styles.navButtonPrev}`} onClick={prevTravel}>
-        <img src={chevronLeft} className={styles.navButtonIcon} />
+        <img src={chevronLeft} className={styles.navButtonIcon} aria-label="이전 여행 옵션 보기" />
       </button>
-      <div className={styles.carousel}>
+      <ol
+        className={styles.carousel}
+        aria-live="polite"
+        aria-label={`총 ${travelOptions.length}개의 여행 옵션 중 ${currentIndex + 1}번째 옵션`}
+      >
         {travelOptions.map((option, index) => (
-          <article
+          <li
             key={index}
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
+            tabIndex={0}
             onClick={() => handleCardClick(option.link)}
+            onKeyDown={(e) => handleKeyPress(e, option.link)}
           >
-            <img src={option.image} className={styles.cardImage} />
+            <img src={option.image} className={styles.cardImage} alt="" />
             <div className={styles.cardContent}>
-              <p className={`${styles.cardTitle} heading-3-text`}>
+              <p
+                className={`${styles.cardTitle} heading-3-text`}
+                aria-label={`출발 ${getParsedCityName(option.departure)} 도착 ${getParsedCityName(
+                  option.destination
+                )}`}
+              >
                 {option.departure} - {option.destination}
               </p>
               <p className={`${styles.cardType} body-text`}>{option.type}</p>
-              <p className={`${styles.cardPrice} body-text`}>KRW {option.price.toLocaleString()}</p>
+              <p
+                className={`${styles.cardPrice} body-text`}
+                aria-label={`가격: ${option.price.toLocaleString()}원`}
+              >
+                KRW {option.price.toLocaleString()}
+              </p>
+              <p className="visually-hidden">클릭하면 예약 페이지로 넘어갑니다.</p>
             </div>
-          </article>
+          </li>
         ))}
-      </div>
-      <button className={`${styles.navButton} ${styles.navButtonNext}`} onClick={nextTravel}>
+      </ol>
+      <button
+        className={`${styles.navButton} ${styles.navButtonNext}`}
+        onClick={nextTravel}
+        aria-label="다음 여행 옵션 보기"
+      >
         <img src={chevronRight} className={styles.navButtonIcon} />
       </button>
     </div>

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -66,7 +66,7 @@ const TravelSection = () => {
       </button>
       <div className={styles.carousel}>
         {travelOptions.map((option, index) => (
-          <div
+          <article
             key={index}
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
             onClick={() => handleCardClick(option.link)}
@@ -79,7 +79,7 @@ const TravelSection = () => {
               <p className={`${styles.cardType} body-text`}>{option.type}</p>
               <p className={`${styles.cardPrice} body-text`}>KRW {option.price.toLocaleString()}</p>
             </div>
-          </div>
+          </article>
         ))}
       </div>
       <button className={`${styles.navButton} ${styles.navButtonNext}`} onClick={nextTravel}>

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -68,7 +68,7 @@ const TravelSection = () => {
   };
 
   return (
-    <div className={styles.travelSection} role="region" aria-label="여행 옵션 캐러셀">
+    <div className={styles.travelSection} aria-label="여행 옵션 캐러셀">
       <button
         className={`${styles.navButton} ${styles.navButtonPrev}`}
         onClick={prevTravel}

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -68,7 +68,7 @@ const TravelSection = () => {
   };
 
   return (
-    <div className={styles.travelSection} role="carousel">
+    <div className={styles.travelSection} role="region" aria-label="여행 옵션 캐러셀">
       <button className={`${styles.navButton} ${styles.navButtonPrev}`} onClick={prevTravel}>
         <img src={chevronLeft} className={styles.navButtonIcon} aria-label="이전 여행 옵션 보기" />
       </button>

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -73,11 +73,13 @@ const TravelSection = () => {
         className={`${styles.navButton} ${styles.navButtonPrev}`}
         onClick={prevTravel}
         aria-label="이전 여행 옵션 보기"
+        type="button"
       >
         <img src={chevronLeft} className={styles.navButtonIcon} alt="" />
       </button>
       <ol
         className={styles.carousel}
+        role="button"
         aria-live="polite"
         aria-label={`총 ${travelOptions.length}개의 여행 옵션 중 ${currentIndex + 1}번째 옵션`}
       >
@@ -115,6 +117,7 @@ const TravelSection = () => {
         className={`${styles.navButton} ${styles.navButtonNext}`}
         onClick={nextTravel}
         aria-label="다음 여행 옵션 보기"
+        type="button"
       >
         <img src={chevronRight} className={styles.navButtonIcon} alt="" />
       </button>

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -69,8 +69,12 @@ const TravelSection = () => {
 
   return (
     <div className={styles.travelSection} role="region" aria-label="여행 옵션 캐러셀">
-      <button className={`${styles.navButton} ${styles.navButtonPrev}`} onClick={prevTravel}>
-        <img src={chevronLeft} className={styles.navButtonIcon} aria-label="이전 여행 옵션 보기" />
+      <button
+        className={`${styles.navButton} ${styles.navButtonPrev}`}
+        onClick={prevTravel}
+        aria-label="이전 여행 옵션 보기"
+      >
+        <img src={chevronLeft} className={styles.navButtonIcon} alt="" />
       </button>
       <ol
         className={styles.carousel}
@@ -112,7 +116,7 @@ const TravelSection = () => {
         onClick={nextTravel}
         aria-label="다음 여행 옵션 보기"
       >
-        <img src={chevronRight} className={styles.navButtonIcon} />
+        <img src={chevronRight} className={styles.navButtonIcon} alt="" />
       </button>
     </div>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -117,3 +117,8 @@ body {
   font-family: Arial, sans-serif;
   background-color: #f5f5f5;
 }
+a {
+  cursor: pointer;
+  color: inherit;
+  text-decoration: none;
+}


### PR DESCRIPTION
## 🔥 결과

<!-- 개선 작업 후 모바일 낭독기를 사용해서 미션 페이지를 읽어보세요 -->

- [배포한 페이지 접근 경로(GitHub Pages)](https://imxyjl.github.io/a11y-airline/)
- 스크린 리더 화면 녹화 영상 (after)
https://github.com/user-attachments/assets/71775a00-7588-4ca0-b065-5bd12cc1f061

소리 대신 자막을 켜고 녹화했습니다.
미션 요구사항이 명확한 캐로셀 부분만 올립니다!

## ✅ 개선 작업 목록
여기서는 각 요구사항을 대략적으로 어떻게 해결했는지만 작성했습니다~!
<!-- 각 요구 사항을 위해 어떤 부분을 고민/학습해보았고, 결과적으로 어떤 개선 작업을 진행했는지 적어주세요-->

**1 컴포넌트 접근성 개선 - 이미지 캐로셀**
- [x]  스크린 리더가 캐로셀의 전체 아이템 수를 읽을 수 있어야 합니다.
    - 대부분의 읽기 요구사항을 `aria-label`을 사용해 만족시켰습니다.
- [x]  스크린 리더가 이미지 캐로셀 내 각 아이템 정보를 읽을 수 있어야 합니다.
    - [x]  여행지, 좌석 유형, 가격 정보를 한번에 읽을 수 있어야 합니다.
        - 캐로셀 전체를 탭하면 캐로셀 내용을 처음부터 끝까지 읽어줍니다.
    - [x]  이전/다음 아이템으로 이동하고 현재 보이는 아이템의 정보를 읽을 수 있어야 합니다.
        - `aria-live="polite"`를 사용해 캐로셀을 넘겼을 때 새로 보이는 캐로셀 내용을 읽습니다.
- [x]  각 아이템을 선택하면 각각에 맞는 링크로 이동할 수 있어야 합니다.
    - `a` 태그 대신 다른 태그를 사용했지만 캐로셀을 클릭하면 해당 상품에 연결된 하이퍼링크로 이동합니다.


**2 페이지 접근성 개선**
- 페이지를 하나의 문서로 읽을 수 있어야 합니다.
    - [x]  페이지에 적절한 제목(title)을 제공하세요. 제목은 페이지의 주요 내용을 간결하게 설명해야 합니다.
        - 항공사 이름 및 항공권을 예매하는 페이지라는 점을 드러내기 위해 “A11Y 항공 좌석 예매”로 설정했습니다.
    - [x]  페이지의 주요 영역을 시맨틱 태그를 사용해 명확히 구분해 주세요
        - 아래를 참고해주세요
    - [x]  헤딩을 논리적인 순서로 사용해 페이지 구조를 명확히 해주세요
        - 기존 App에서는 항공사를 소개하는 곳과 항공편을 소개하는 곳에서 h1 태그를 사용하고 있었는데, 시맨틱하게 h1을 사용하려면 한 페이지 안에 하나의 h1만 있어야 합니다.
            → 항공사의 메인 페이지인 만큼 항공사 소개가 가장 중요한 section이라 생각해서 항공사 소개의 h1을 살리고, 항공편 소개의 heading은 h2로 변경했습니다.
            
- [x]  키보드 사용자를 위해 페이지 최상단에 '본문으로 바로가기' 링크를 제공해 반복되는 메뉴를 건너뛸 수 있게 해주세요. 
    - 페이지에 처음 들어와서 Tab 키를 누르면 `SkipToContent` 컴포넌트가 등장합니다. 이 컴포넌트를 클릭하거나 포커싱된 상태에서 Enter를 누르면 Content Section(본문)으로 이동합니다.
        - 페이지에서 가장 핵심이 되는 부분은 main 태그 이하의 표 예매 부분이지만, 일반적으로 Skip link 요소는 반복되는 부분을 건너뛰는 UI인 것 같아 main 위의 header 부분까지 본문으로 간주했습니다.

<br>

> 이하는 어떤 고민을 했는지 자세히 적어둔 부분이라 리뷰 하시면서 궁금한 점이 있을 때 참고해보시면 좋을 것 같습니다!


## 시맨틱 태그

- 기본적인 `header`, `footer`, `main`, `section` 태그 사용
- `nav`
    - 한 페이지 내에 여러 개의 nav 태그를 사용할 수 있어 여러 번 사용했습니다. 다만 이런 경우 aria 속성들을 이용해 역할을 명시하는 게 좋다고 합니다.
    - → 현재 UI가 상위 `<nav>`를 hover하면 하위 `<nav>`가 나오는 방식이지만, 시각 정보가 없을 때는 두 단계를 명확히 구분하기 어려울 것 같아 `aria-label`로 두 `<nav>`의 역할을 명시했습니다.
        - 고민: 이중 `<nav>`를 사용하긴 했지만, 상위 `<nav>`는 페이지 이동
        - 
        - 을 유발하지는 않기 때문에 과연 nav로 감쌀 수 있을지가 의문이었습니다.
        - 하지만 네비게이션 작업의 시작점이 되는 컴포넌트라 생각해서 이중으로 적용했습니다.
- `ol`
    - 캐러셀에 적용
    - 미션 요구사항에 현재 캐로셀이 n번째임을 설명하라고 나와 있었고, 실제 캐로셀도 성격이 같은 여행상품을 쭉 보여주는 형식이라 순서가 있다고 생각하고 ol 태그를 적용했습니다.
- `a`
    - `SkipToContent`에 적용
    - 캐러셀 내부를 a로 감싸기 (미적용)
        - 하이퍼링크를 제공하는 구역이므로 a 태그를 사용하려고 했는데 다음과 같은 문제가 있었습니다.
            
            ```html
            // a 태그를 사용했을 때의 대략적인 구조
            <ol>	
              <li>
            	<a>
            	  <img />
            	    ...
            	 </a>
              </li>
            </ol>
            ```
            
            1. `a` 태그 이하에 기존 캐로셀 요소들을 자식 요소로 넣기
                
                : 스크린 리더가 **현재 캐로셀을 총 2회 읽는 문제**가 있었습니다. 캐로셀에 `aria-live="polite"` 를 걸어 놨기 때문에 새 캐로셀이 나타나면 먼저 1회 읽고 이어서 한번 더 읽었습니다.
                
                새 캐로셀이 나타났을 때 아무 요소도 읽어주지 않는 것도, 이미 읽은 캐로셀을 바로 한번 더 읽는 것도 사용자 경험을 저하시킬 것 같다고 생각했습니다.
                
            2. `a` 태그를 기존 캐로셀 요소들과 형제 관계로 두기
                
                : 2회 읽는 문제는 사라지지만 tab 키를 사용해 캐로셀에 접근했을 때 **캐로셀에 focus가 시각적으로 보이지 않는 문제**가 새로 생겼습니다. 
                
                a 태그를 이용하는 이유 중 하나가 기본 동작들(키보드 이동, 엔터 키 입력시 하이퍼링크로 이동 등)을 지원해주기 때문이라고 생각하는데, 키보드로 이동했을 때 포커스를 확인할 수 없다면 사용하는 데 불편함이 있을 것 같았습니다.
                
                → 따라서 캐로셀에는 시맨틱 태그를 포기하고 li 태그에 `tabIndex={0}`과  `onKeyDown` 이벤트 핸들러를 추가해 키보드 접근성을 직접 구현했습니다.
                

## ARIA 적용

- `aria-label`
    - 캐로셀 컴포넌트 위주로 사용했습니다. 예시에 나와있듯 캐로셀을 읽을 때 화면에 나온 그대로 읽는 것보다는 출발, 도착지를 명시적으로 읽어주는 게 좋다고 생각해 `aria-label`을 추가했습니다.

## 기타 접근성

- `visually-hidden`
    - 캐로셀 마지막에 예약 페이지를 안내하는 p 태그에 적용했습니다.  
        스크린 리더를 사용하는 사용자에게만 전달하면 되는 추가 문구이기 때문입니다.
        
- `alt`
    - 캐로셀의 이미지는 도착지의 대표적인 랜드마크 사진이기 때문에 도착지를 읽어주는 상황에서 중복해서 읽어줄 필요가 없다고 생각해 빈 문자열을 사용했습니다.
- 키보드 접근성
    - 기본적으로 사용자와의 추가 상호작용이 있는 부분에만 tab 키를 사용할 수 있도록 했습니다.
        - 예) `header`: 단순 텍스트만 제공하므로 tab으로 이동 불가     
            `nav`: 사용자가 링크를 타고 이동할 수 있으므로 tab으로 이동 가능

<br>

## 🧐 우리 팀의 접근성 체크리스트

## 핵심 플로우

제가 개발하고 있는 리뷰미 서비스의 핵심 플로우는 리뷰 쓰기와 읽기입니다.

하나만 선택하라고 하는데 쓰지 않으면 리뷰를 볼 수 없고, 리뷰를 확인하지 않는다면 쓸 이유도 없기에 둘 다 필수 플로우라고 생각합니다.

따라서 두 가지 플로우를 모바일 스크린 리더를 이용해 체험해봤습니다.

### 화면을 볼 수 없는 사용자가 이 단계를 완료할 수 있는가?
![image](https://github.com/user-attachments/assets/d355c2bc-b655-4113-b937-96a0146054f5)

- 리뷰 쓰기
    - 화면을 볼 수 없다면 불편할 것 같습니다.
        
        각 질문마다 선지를 하나 이상 선택해야 다음으로 넘어가는 버튼이 활성화되는데, 버튼이 비활성화된 상태에서는 버튼 요소를 탭해도 별다른 안내가 뜨지 않습니다.
        
    - 그리고 넘어가기 위한 조건들이 아예 읽히지 않거나 불편한 동작을 거쳐야 알게 되는 부분이 많아 다음으로 넘어가기가 어렵습니다.
- 리뷰 읽기
![image](https://github.com/user-attachments/assets/28585a67-d1b5-4cf1-993c-2374b733b796)

    - 리뷰를 읽기 위해 모달에 비밀번호를 입력해야 하는데 모달에 대한 접근성 조치가 없어 불편합니다.
    - 그 외에는 이용은 가능하지만, 몇 번째 리뷰임을 알려준다거나, 자동 읽기 기능 및 aria-label으로 더 상세한 설명을 전달하면 접근성이 더 높아질 것 같습니다.

## 접근성 개선 우선순위

핵심 플로우에 가장 가까우면서도 기본적인 진행에 차질이 있는 것들을 우선으로 리스트를 추렸습니다.

1. 리뷰 작성에 있어 필요한 사전 정보 명확하게 알려주기 (선택할 수 있는 문항 개수, 다음으로 넘어가는 조건 등)
2. 모달 접근성 개선하기 - 모달 등장을 알려주기, 내용 자동으로 읽어주기 등
3. 다음 리뷰 작성 섹션으로 넘어갔을 때 progress bar부터 자동으로 읽어주기
4. 체크박스 레이블에서 이모지와 텍스트를 분리하기 (이모지는 읽지 않도록)
5. aria-label을 통해 텍스트의 의미 부연설명하기
6. progress bar, breadcrumb같은 부가적인 컴포넌트에 role 부여하기
7. 작성 내용 확인 모달이 띄워지면 처음부터 끝까지 자동으로 읽어주기
8. 캐러셀 이미지로 적용되는 사용 설명서를 별도의 텍스트로 제공하기
9. 리뷰 상세 페이지에 들어가면 내용 자동으로 읽어주기


