### PR TITLE
[항공사 웹사이트의 컴포넌트 접근성 높이기] 해시(김가연) 미션 제출합니다

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "deploy": "npm run build && npx gh-pages -d dist"
   },
   "author": "woowacourse",
-  "homepage": "https://{username}.github.io/a11y-airline",
+  "homepage": "https://dle234.github.io/a11y-airline",
   "license": "MIT",
   "dependencies": {
     "react": "^18.3.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,30 +2,36 @@ import styles from './App.module.css';
 import Navigation from './components/Navigation';
 import FlightBooking from './components/FlightBooking';
 import TravelSection from './components/TravelSection';
+import { useEffect } from 'react';
 // import PromotionModal from './components/PromotionModal';
 
 function App() {
+  useEffect(() => {
+    document.title = 'A11Y AIRLINE 메인 페이지 - 항공권 예매 및 추천 여행지';
+  }, []);
+
   return (
     <div className={styles.app}>
+      <a href="#main-content" className={styles.skipLink} title="본문으로 바로가기" />
       <Navigation />
-      <div className={styles.header}>
+      <header className={styles.header}>
         <h1 className={`${styles.title} heading-1-text`}>A11Y AIRLINE</h1>
         <p className="body-text">
           A11Y AIRLINE은 고객 여러분의 안전하고 쾌적한 여행을 위해 최선을 다하고 있습니다.
         </p>
-      </div>
-      <div id="main-content" className={styles.main}>
-        <div className={styles.flightBooking}>
+      </header>
+      <main id="main-content" className={styles.main}>
+        <section className={styles.flightBooking}>
           <FlightBooking />
-        </div>
-        <div className={styles.travelSection}>
-          <h1 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h1>
+        </section>
+        <section className={styles.travelSection}>
+          <h2 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h2>
           <TravelSection />
-        </div>
-      </div>
-      <div className={styles.footer}>
+        </section>
+      </main>
+      <footer className={styles.footer}>
         <p className="body-text">&copy; A11Y AIRLINE</p>
-      </div>
+      </footer>
       {/* 추가 CHALLENGE: 모달 포커스 트랩 */}
       {/* <PromotionModal /> */}
     </div>

--- a/src/components/TravelSection.module.css
+++ b/src/components/TravelSection.module.css
@@ -21,6 +21,10 @@
 
 .cardActive {
   display: block;
+  text-align: left;
+  border: none;
+  padding: 0;
+  margin: 0;
 }
 
 .cardImage {

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -59,17 +59,36 @@ const TravelSection = () => {
     window.open(link, '_blank', 'noopener,noreferrer');
   };
 
+  const getCurrentIndex = (index: number) => {
+    return `여행${travelOptions.length}개의 세계 여행 상품 중 ${index + 1}번째 상품`;
+  };
+
+  const getCurrentDescription = (option: TravelOption) => {
+    const { departure, destination, type, price } = option;
+
+    return `${departure}에서 출발해 ${destination}에 도착하는 ${price}원 ${type} 상품입니다. 선택하면 예약 페이지로 이동합니다.`;
+  };
+
   return (
-    <section className={styles.travelSection}>
-      <button className={`${styles.navButton} ${styles.navButtonPrev}`} onClick={prevTravel}>
+    <div className={styles.travelSection}>
+      <p aria-live="polite" className="visually-hidden">
+        {getCurrentIndex(currentIndex)}
+      </p>
+      <button
+        aria-label="이전 여행 상품"
+        className={`${styles.navButton} ${styles.navButtonPrev}`}
+        onClick={prevTravel}
+      >
         <img src={chevronLeft} className={styles.navButtonIcon} />
       </button>
-      <ul className={styles.carousel}>
+
+      <div className={styles.carousel}>
         {travelOptions.map((option, index) => (
-          <li
+          <button
             key={index}
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
             onClick={() => handleCardClick(option.link)}
+            aria-label={getCurrentDescription(option)}
           >
             <img src={option.image} className={styles.cardImage} />
             <article className={styles.cardContent}>
@@ -79,13 +98,17 @@ const TravelSection = () => {
               <p className={`${styles.cardType} body-text`}>{option.type}</p>
               <p className={`${styles.cardPrice} body-text`}>KRW {option.price.toLocaleString()}</p>
             </article>
-          </li>
+          </button>
         ))}
-      </ul>
-      <button className={`${styles.navButton} ${styles.navButtonNext}`} onClick={nextTravel}>
+      </div>
+      <button
+        aria-label="다음 여행 상품"
+        className={`${styles.navButton} ${styles.navButtonNext}`}
+        onClick={nextTravel}
+      >
         <img src={chevronRight} className={styles.navButtonIcon} />
       </button>
-    </section>
+    </div>
   );
 };
 

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -60,32 +60,32 @@ const TravelSection = () => {
   };
 
   return (
-    <div className={styles.travelSection}>
+    <section className={styles.travelSection}>
       <button className={`${styles.navButton} ${styles.navButtonPrev}`} onClick={prevTravel}>
         <img src={chevronLeft} className={styles.navButtonIcon} />
       </button>
-      <div className={styles.carousel}>
+      <ul className={styles.carousel}>
         {travelOptions.map((option, index) => (
-          <div
+          <li
             key={index}
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
             onClick={() => handleCardClick(option.link)}
           >
             <img src={option.image} className={styles.cardImage} />
-            <div className={styles.cardContent}>
+            <article className={styles.cardContent}>
               <p className={`${styles.cardTitle} heading-3-text`}>
                 {option.departure} - {option.destination}
               </p>
               <p className={`${styles.cardType} body-text`}>{option.type}</p>
               <p className={`${styles.cardPrice} body-text`}>KRW {option.price.toLocaleString()}</p>
-            </div>
-          </div>
+            </article>
+          </li>
         ))}
-      </div>
+      </ul>
       <button className={`${styles.navButton} ${styles.navButtonNext}`} onClick={nextTravel}>
         <img src={chevronRight} className={styles.navButtonIcon} />
       </button>
-    </div>
+    </section>
   );
 };
 


### PR DESCRIPTION
## 🔥 결과

<!-- 개선 작업 후 모바일 낭독기를 사용해서 미션 페이지를 읽어보세요 -->

- 배포한 페이지 접근 경로(GitHub Pages): [🍀link](https://dle234.github.io/a11y-airline/) 
- 스크린 리더 화면 녹화 영상 (before / after)
before

https://github.com/user-attachments/assets/5349901b-19c4-490c-9983-5a94678aa027

after

https://github.com/user-attachments/assets/5e34d32e-3fc8-48b4-a9da-730eb1715bc1



## ✅ 개선 작업 목록
### 컴포넌트 접근성 개선
1.  캐로셀의 전체 아이템 수를 읽을 수 있어야 한다.
```js
  <p aria-live="polite" className="visually-hidden">
        {getCurrentIndex(currentIndex)}
      </p>
```
- 이벤트가 발생했을때 실시간으로 반영된 내용을 읽어줄 수 있도록 p 태그를 추가했습니다. 

2. 현재 보이는 캐로셀 내 정보 한번에 읽기, 각 아이템을 선택하면 각각에 맞는 링크로 이동할 수 있어야 한다.
```js
 <button
            key={index}
            className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
            onClick={() => handleCardClick(option.link)}
            aria-label={getCurrentDescription(option)}
          >
        ...
          </button>
```
- aria-label 를 사용해서 정보를 한번에 읽을 수 있도록 했습니다.
- button 태그로 수정하여 클릭 이벤트가 적용될 수 있도록 했습니다.
- '선택하면 예약 페이지로 이동합니다.' 라는 내용이 들어가려면 focus 가 해당 화면에 위치해야한다고 생각해서 상품 index 와 내용을 나누었습니다.

### 페이지 접근성 개선
1. 페이지 제목, 시맨틱 태그, 순서 
- 제목
```js
 useEffect(() => {
    document.title = 'A11Y AIRLINE 메인 페이지 - 항공권 예매 및 추천 여행지';
  }, []);
```
useEffect 를 활용하여 각 페이지마다 title 을 다르게 넣을 수 있도록 했습니다.
title 에는 페이지 정보, 제공되는 서비스가 요약되어있습니다.

- 시맨틱 태그
header, section, footer, a 태그 등을 이용해서 적절한 시맨틱 태그로 구성하도록 수정했습니다.

- h1, h2 에 따른 태그를 활용하여 페이지 구조를 명확히 했습니다.

2. '본문으로 바로가기' 링크를 제공
```js
 <a href="#main-content" className={styles.skipLink} title="본문으로 바로가기" />
```
스킵 네비게이션(skip navigation) 을 활용하여 main-content로 바로 이동할 수 있는 링크를 넣어주었습니다.

### 체크리스트

**1 컴포넌트 접근성 개선 - 이미지 캐로셀**
- [X] 스크린 리더가 캐로셀의 전체 아이템 수를 읽을 수 있어야 합니다.
- [X] 스크린 리더가 이미지 캐로셀 내 각 아이템 정보를 읽을 수 있어야 합니다.
  - [X] 여행지, 좌석 유형, 가격 정보를 한번에 읽을 수 있어야 합니다.
  - [X] 이전/다음 아이템으로 이동하고 현재 보이는 아이템의 정보를 읽을 수 있어야 합니다.
- [X] 각 아이템을 선택하면 각각에 맞는 링크로 이동할 수 있어야 합니다.

**2 페이지 접근성 개선**
- [X] 페이지를 하나의 문서로 읽을 수 있어야 합니다.
  - [X] 페이지에 적절한 제목(title)을 제공하세요. 제목은 페이지의 주요 내용을 간결하게 설명해야 합니다.
  - [X] 페이지의 주요 영역을 시맨틱 태그를 사용해 명확히 구분해 주세요
  - [X] 헤딩을 논리적인 순서로 사용해 페이지 구조를 명확히 해주세요
- [X] 키보드 사용자를 위해 페이지 최상단에 '본문으로 바로가기' 링크를 제공해 반복되는 메뉴를 건너뛸 수 있게 해주세요

## 🧐 우리 팀의 접근성 체크리스트

- 우리 팀 서비스에서 가장 중요하고 자주 사용되는 기능 플로우
<img width="1179" alt="image" src="https://github.com/user-attachments/assets/68ded5f0-18f7-4347-8969-84705b2c885c">


- 우리 팀만의 접근성 체크리스트
<img width="346" alt="image" src="https://github.com/user-attachments/assets/eae123c2-df9e-45a8-9955-e4a5d7e63a8e">
//TODO: 추후에 ,, 글로 수정하도록 하겠습니다! 
