### PR TITLE
[항공사 웹사이트의 컴포넌트 접근성 높이기] 해리(최현웅) 미션 제출합니다.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,15 +1,13 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AllY HARRY AIRLINE</title>
+  </head>
 
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>React App</title>
-</head>
-
-<body>
-  <div id="root"></div>
-  <script type="module" src="/src/main.tsx"></script>
-</body>
-
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "deploy": "npm run build && npx gh-pages -d dist"
   },
   "author": "woowacourse",
-  "homepage": "https://{username}.github.io/a11y-airline",
+  "homepage": "https://hwink.github.io/a11y-airline",
   "license": "MIT",
   "dependencies": {
     "react": "^18.3.1",

--- a/src/App.module.css
+++ b/src/App.module.css
@@ -1,4 +1,5 @@
 .app {
+  position: relative;
   font-family: Arial, sans-serif;
   max-width: 480px;
   width: 100%;
@@ -9,6 +10,29 @@
   margin: 0 auto;
 }
 
+.skipLink {
+  position: absolute;
+  top: -40px;
+  left: 0;
+  transition: top 0.4s ease-in-out;
+  text-decoration: none;
+  background-color: #333333;
+  color: #fff;
+  padding: 8px 16px;
+  z-index: 1;
+  border: none;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2); /* 기본 box-shadow 스타일 */
+}
+
+.skipLink:focus {
+  clip: auto;
+  top: 0;
+  height: 48px;
+  width: auto;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
 .header {
   padding: 48px 24px 24px 24px;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,14 +7,17 @@ import TravelSection from './components/TravelSection';
 function App() {
   return (
     <div className={styles.app}>
+      <a href="#main-content" className={styles.skipLink}>
+        본문으로 바로가기
+      </a>
       <Navigation />
-      <div className={styles.header}>
+      <header className={styles.header}>
         <h1 className={`${styles.title} heading-1-text`}>A11Y AIRLINE</h1>
         <p className="body-text">
           A11Y AIRLINE은 고객 여러분의 안전하고 쾌적한 여행을 위해 최선을 다하고 있습니다.
         </p>
-      </div>
-      <div id="main-content" className={styles.main}>
+      </header>
+      <main id="main-content" className={styles.main}>
         <div className={styles.flightBooking}>
           <FlightBooking />
         </div>
@@ -22,10 +25,10 @@ function App() {
           <h1 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h1>
           <TravelSection />
         </div>
-      </div>
-      <div className={styles.footer}>
-        <p className="body-text">&copy; A11Y AIRLINE</p>
-      </div>
+      </main>
+      <footer className={styles.footer}>
+        <p className="body-text">&copy; HARRY AIRLINE</p>
+      </footer>
       {/* 추가 CHALLENGE: 모달 포커스 트랩 */}
       {/* <PromotionModal /> */}
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,7 +22,7 @@ function App() {
           <FlightBooking />
         </div>
         <div className={styles.travelSection}>
-          <h1 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h1>
+          <h2 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h2>
           <TravelSection />
         </div>
       </main>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,13 +18,13 @@ function App() {
         </p>
       </header>
       <main id="main-content" className={styles.main}>
-        <div className={styles.flightBooking}>
+        <section className={styles.flightBooking}>
           <FlightBooking />
-        </div>
-        <div className={styles.travelSection}>
+        </section>
+        <section className={styles.travelSection}>
           <h2 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h2>
           <TravelSection />
-        </div>
+        </section>
       </main>
       <footer className={styles.footer}>
         <p className="body-text">&copy; HARRY AIRLINE</p>

--- a/src/components/FlightBooking.tsx
+++ b/src/components/FlightBooking.tsx
@@ -36,16 +36,11 @@ const FlightBooking = () => {
             <img src={minus} alt="" />
           </button>
           {messageForATUser && (
-            <div
-              className="visually-hidden"
-              aria-live="polite"
-              aria-atomic="true"
-              aria-relevant="additions"
-            >
+            <div className="visually-hidden" aria-live="polite">
               <p>{messageForATUser}</p>
             </div>
           )}
-          <span aria-live="polite">{adultCount}</span>
+          <span>{adultCount}</span>
           <button className="button-text" onClick={incrementCount} aria-label="성인 승객 증가">
             <img src={plus} alt="" />
           </button>

--- a/src/components/FlightBooking.tsx
+++ b/src/components/FlightBooking.tsx
@@ -1,38 +1,16 @@
-import { useCallback, useState } from 'react';
+import { useState } from 'react';
 
 import helpIcon from '../assets/help.svg';
 import plus from '../assets/plus.svg';
 import minus from '../assets/minus.svg';
 
 import styles from './FlightBooking.module.css';
-
-const MIN_PASSENGERS = 1;
-const MAX_PASSENGERS = 3;
+import useAdultCount from '../hooks/useAdultCount';
 
 const FlightBooking = () => {
-  const [adultCount, setAdultCount] = useState(MIN_PASSENGERS);
-  const [statusMessage, setStatusMessage] = useState('');
   const [showTooltip, setShowTooltip] = useState(false);
-
-  const incrementCount = useCallback(() => {
-    if (adultCount === MAX_PASSENGERS) {
-      setStatusMessage('최대 승객 수에 도달했습니다');
-      return;
-    }
-
-    setAdultCount((prev) => Math.min(MAX_PASSENGERS, prev + 1));
-    setStatusMessage('');
-  }, [adultCount]);
-
-  const decrementCount = useCallback(() => {
-    if (adultCount === MIN_PASSENGERS) {
-      setStatusMessage('최소 1명의 승객이 필요합니다');
-      return;
-    }
-
-    setAdultCount((prev) => Math.max(MIN_PASSENGERS, prev - 1));
-    setStatusMessage('');
-  }, [adultCount]);
+  const { adultCount, incrementCount, decrementCount, alertMessage, messageForATUser } =
+    useAdultCount();
 
   return (
     <div className={styles.flightBooking}>
@@ -46,22 +24,36 @@ const FlightBooking = () => {
             onMouseLeave={() => setShowTooltip(false)}
           >
             <img src={helpIcon} alt="도움말" className={styles.helpIcon} />
-            {showTooltip && <div className={styles.tooltip}>최대 3명까지 예약할 수 있습니다</div>}
+            {showTooltip && (
+              <div className={styles.tooltip} role="alert">
+                최대 3명까지 예약할 수 있습니다
+              </div>
+            )}
           </div>
         </div>
         <div className={styles.counter}>
           <button className="button-text" onClick={decrementCount} aria-label="성인 승객 감소">
             <img src={minus} alt="" />
           </button>
+          {messageForATUser && (
+            <div
+              className="visually-hidden"
+              aria-live="polite"
+              aria-atomic="true"
+              aria-relevant="additions"
+            >
+              <p>{messageForATUser}</p>
+            </div>
+          )}
           <span aria-live="polite">{adultCount}</span>
           <button className="button-text" onClick={incrementCount} aria-label="성인 승객 증가">
             <img src={plus} alt="" />
           </button>
         </div>
       </div>
-      {statusMessage && (
+      {alertMessage && (
         <div className="visually-hidden" role="alert">
-          {statusMessage}
+          {alertMessage}
         </div>
       )}
       <button className={styles.searchButton}>항공편 검색</button>

--- a/src/components/TravelSection.module.css
+++ b/src/components/TravelSection.module.css
@@ -40,6 +40,11 @@
   bottom: 0;
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.9) 26%, rgba(255, 255, 255, 0) 100%);
   padding: 24px 16px;
+
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  align-items: flex-start;
 }
 
 .cardTitle {

--- a/src/components/TravelSection.module.css
+++ b/src/components/TravelSection.module.css
@@ -17,6 +17,7 @@
   display: none;
   width: 100%;
   height: 246px;
+  padding: 0;
 }
 
 .cardActive {
@@ -85,4 +86,16 @@
 .navButtonIcon {
   width: 24px;
   height: 24px;
+}
+
+.visuallyHidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -48,9 +48,9 @@ const getItemDetailMessage = (index: number) => {
   const targetItem = travelOptions[index];
   const { departure, destination, type, price } = targetItem;
 
-  const itemDetailMessageForATUser = `${departure}출발 ${destination}도착 ${type} 가격${price.toLocaleString(
+  const itemDetailMessageForATUser = `${departure}출발, ${destination}도착, ${type} 가격${price.toLocaleString(
     'ko-KR'
-  )}원 선택하면 예약 페이지로 이동합니다.`;
+  )}원, 선택하면 예약 페이지로 이동합니다.`;
   return itemDetailMessageForATUser;
 };
 
@@ -72,7 +72,6 @@ const TravelSection = () => {
   const itemSequenceMessageForATUser = `${travelOptions.length}개의 여행 상품 중 ${
     currentIndex + 1
   }번 째 상품`;
-  const itemDetailMessageForATUser = getItemDetailMessage(currentIndex);
 
   return (
     <div className={styles.travelSection}>
@@ -85,14 +84,14 @@ const TravelSection = () => {
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
             // onClick과 같은 사용자와 상호작용을 하기 위한 태그는 div보다는 button이 적합.
             onClick={() => handleCardClick(option.link)}
-            aria-label={itemDetailMessageForATUser}
+            aria-label={getItemDetailMessage(index)}
           >
             <img src={option.image} className={styles.cardImage} />
             {/* 스크린리더가 아래 정보는 읽지 않을 수 있도록 aria-hidden 속성 사용. */}
             <div className={styles.cardContent} aria-hidden>
-              <p className={`${styles.c2ardTitle} heading-3-text`}>
+              <h3 className={`${styles.cardTitle} heading-3-text`}>
                 {option.departure} - {option.destination}
-              </p>
+              </h3>
               <p className={`${styles.cardType} body-text`}>{option.type}</p>
               <p className={`${styles.cardPrice} body-text`}>KRW {option.price.toLocaleString()}</p>
             </div>

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -44,6 +44,16 @@ const travelOptions: TravelOption[] = [
   }
 ];
 
+const getItemDetailMessage = (index: number) => {
+  const targetItem = travelOptions[index];
+  const { departure, destination, type, price } = targetItem;
+
+  const itemDetailMessageForATUser = `${departure}출발 ${destination}도착 ${type} 가격${price.toLocaleString(
+    'ko-KR'
+  )}원 선택하면 예약 페이지로 이동합니다.`;
+  return itemDetailMessageForATUser;
+};
+
 const TravelSection = () => {
   const [currentIndex, setCurrentIndex] = useState(0);
 
@@ -59,30 +69,49 @@ const TravelSection = () => {
     window.open(link, '_blank', 'noopener,noreferrer');
   };
 
+  const itemSequenceMessageForATUser = `${travelOptions.length}개의 여행 상품 중 ${
+    currentIndex + 1
+  }번 째 상품`;
+  const itemDetailMessageForATUser = getItemDetailMessage(currentIndex);
+
   return (
     <div className={styles.travelSection}>
-      <button className={`${styles.navButton} ${styles.navButtonPrev}`} onClick={prevTravel}>
-        <img src={chevronLeft} className={styles.navButtonIcon} />
-      </button>
-      <div className={styles.carousel}>
+      {/* ScreenReaderOnly 컴포넌트 만들어서 활용하기, toss참고, 리뷰 반영하면서 구현 예정(@해리) */}
+      <div className={styles.carousel} aria-live="polite">
+        <div className={styles.visuallyHidden}>{itemSequenceMessageForATUser}</div>
         {travelOptions.map((option, index) => (
-          <div
+          <button
             key={index}
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
+            // onClick과 같은 사용자와 상호작용을 하기 위한 태그는 div보다는 button이 적합.
             onClick={() => handleCardClick(option.link)}
+            aria-label={itemDetailMessageForATUser}
           >
             <img src={option.image} className={styles.cardImage} />
-            <div className={styles.cardContent}>
-              <p className={`${styles.cardTitle} heading-3-text`}>
+            {/* 스크린리더가 아래 정보는 읽지 않을 수 있도록 aria-hidden 속성 사용. */}
+            <div className={styles.cardContent} aria-hidden>
+              <p className={`${styles.c2ardTitle} heading-3-text`}>
                 {option.departure} - {option.destination}
               </p>
               <p className={`${styles.cardType} body-text`}>{option.type}</p>
               <p className={`${styles.cardPrice} body-text`}>KRW {option.price.toLocaleString()}</p>
             </div>
-          </div>
+          </button>
         ))}
       </div>
-      <button className={`${styles.navButton} ${styles.navButtonNext}`} onClick={nextTravel}>
+      {/* 스크린 리더는 문서의 흐름대로 aria-label을 읽기 때문에 여행 상세 정보를 먼저 읽을 수 있도록 HTML 마크업 순서 수정 */}
+      <button
+        className={`${styles.navButton} ${styles.navButtonPrev}`}
+        onClick={prevTravel}
+        aria-label="이전 여행 상품"
+      >
+        <img src={chevronLeft} className={styles.navButtonIcon} />
+      </button>
+      <button
+        className={`${styles.navButton} ${styles.navButtonNext}`}
+        onClick={nextTravel}
+        aria-label="다음 여행 상품"
+      >
         <img src={chevronRight} className={styles.navButtonIcon} />
       </button>
     </div>

--- a/src/hooks/useAdultCount.ts
+++ b/src/hooks/useAdultCount.ts
@@ -7,7 +7,7 @@ const MAX_PASSENGERS = 3;
 const useAdultCount = () => {
   const [adultCount, setAdultCount] = useState(1);
   const [alertMessage, setAlertMessage] = useState('');
-  const { handleDebouncedMessage, messageForATUser } = useDebouncedATMessage(200);
+  const { handleDebouncedMessage, messageForATUser } = useDebouncedATMessage(500);
 
   const incrementCount = () => {
     if (adultCount + 1 > MAX_PASSENGERS) {

--- a/src/hooks/useAdultCount.ts
+++ b/src/hooks/useAdultCount.ts
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+import useDebouncedATMessage from './useDebouncedATMessage';
+
+const MIN_PASSENGERS = 1;
+const MAX_PASSENGERS = 3;
+
+const useAdultCount = () => {
+  const [adultCount, setAdultCount] = useState(1);
+  const [alertMessage, setAlertMessage] = useState('');
+  const { handleDebouncedMessage, messageForATUser } = useDebouncedATMessage(200);
+
+  const incrementCount = () => {
+    if (adultCount + 1 > MAX_PASSENGERS) {
+      alert('최대 승객 수에 도달했습니다');
+      setAlertMessage('최대 승객 수에 도달했습니다');
+      return;
+    }
+    if (alertMessage) {
+      setAlertMessage('');
+    }
+
+    handleDebouncedMessage(`성인 승객 수는 ${adultCount + 1}명 입니다.`);
+    setAdultCount((prev) => Math.min(MAX_PASSENGERS, prev + 1));
+  };
+
+  const decrementCount = () => {
+    if (adultCount === MIN_PASSENGERS) {
+      alert('최소 1명의 승객이 필요합니다');
+      setAlertMessage('최소 1명의 승객이 필요합니다');
+      return;
+    }
+    if (alertMessage) {
+      setAlertMessage('');
+    }
+
+    handleDebouncedMessage(`성인 승객 수는 ${adultCount - 1}명 입니다.`);
+    setAdultCount((prev) => Math.max(1, prev - 1));
+  };
+
+  return {
+    adultCount,
+    incrementCount,
+    decrementCount,
+    alertMessage,
+    messageForATUser
+  };
+};
+
+export default useAdultCount;

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,0 +1,22 @@
+import { useCallback, useRef } from 'react';
+
+const useDebounce = <T extends (...args: Parameters<T>) => void>(func: T, delayTime: number) => {
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const debouncedCallback = useCallback(
+    (...args: Parameters<T>) => {
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+      }
+
+      debounceRef.current = setTimeout(() => {
+        func(...args);
+      }, delayTime);
+    },
+    [func, delayTime]
+  );
+
+  return debouncedCallback;
+};
+
+export default useDebounce;

--- a/src/hooks/useDebouncedATMessage.ts
+++ b/src/hooks/useDebouncedATMessage.ts
@@ -1,0 +1,22 @@
+import { useState } from 'react';
+import useDebounce from './useDebounce';
+
+const MESSAGE_MAINTAIN_TIME = 500;
+
+const useDebouncedATMessage = (delayTime: number) => {
+  const [messageForATUser, setMessageForATUser] = useState('');
+
+  const handleDebouncedMessage = useDebounce((message: string) => {
+    setMessageForATUser(message);
+    setTimeout(() => {
+      setMessageForATUser('');
+    }, MESSAGE_MAINTAIN_TIME);
+  }, delayTime);
+
+  return {
+    messageForATUser,
+    handleDebouncedMessage
+  };
+};
+
+export default useDebouncedATMessage;


### PR DESCRIPTION
## 🔥 결과

안녕하세요 리안, 리뷰 요청합니다.

<!-- 개선 작업 후 모바일 낭독기를 사용해서 미션 페이지를 읽어보세요 -->

- 배포한 페이지 접근 경로(GitHub Pages): https://hwinkr.github.io/a11y-airline/
- 스크린 리더 화면 녹화 영상 (before / after)

## ✅ 개선 작업 목록

<!-- 각 요구 사항을 위해 어떤 부분을 고민/학습해보았고, 결과적으로 어떤 개선 작업을 진행했는지 적어주세요-->

## 1 컴포넌트 접근성 개선 - 이미지 캐로셀

- [x] 스크린 리더가 캐로셀의 전체 아이템 수를 읽을 수 있어야 합니다.  

스크린 리더가 캐로셀의 전체 아이템 수를 읽을 수 있도록, 현재 여행 상품을 가르키는 인덱스 값이 변경될 때마다 스크린 리더 사용자가 듣게 될 메시지를 다르게 만들 수 있도록 했습니다.
```tsx
const itemSequenceMessageForATUser = `${travelOptions.length}개의 여행 상품 중 ${
  currentIndex + 1
}번 째 상품`;

//...

return (
  <div className={styles.travelSection}>
    {/* TODO */}
    {/* ScreenReaderOnly 컴포넌트 만들어서 활용하기 */}
    <div className={styles.visuallyHidden} aria-live="polite">
      {itemSequenceMessageForATUser}
    </div>
  {/* ... */}
)
```
- [x] 스크린 리더가 이미지 캐로셀 내 각 아이템 정보를 읽을 수 있어야 합니다.   
  - [x] 여행지, 좌석 유형, 가격 정보를 한번에 읽을 수 있어야 합니다.
  - [x] 이전/다음 아이템으로 이동하고 현재 보이는 아이템의 정보를 읽을 수 있어야 합니다.
  - [x] 각 아이템을 선택하면 각각에 맞는 링크로 이동할 수 있어야 합니다.  

이미지 캐로셀의 각 이미지를 button 태그로 감쌌습니다. onClick과 같은 사용자와 상호작용을 위한 이벤트는 div보다 button을 사용해야 합니다. 
[jsx-a11y 라이브러리의 권장 사항](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/4925ba8d0bf80a4b1d8e8645d310590bf1b40b64/docs/rules/no-static-element-interactions.md)을 참고하면 해당 내용을 확인할 수 있습니다. div 태그를 버튼 태그로 변경하고 `aria-label` 속성을 사용해서 각 버튼이 어떤 여행 상품인지 읽을 수 있도록 했습니다.
```ts
const getItemDetailMessage = (index: number) => {
  const targetItem = travelOptions[index];
  const { departure, destination, type, price } = targetItem;

  const itemDetailMessageForATUser = `${departure}출발 ${destination}도착 ${type} 가격${price.toLocaleString(
    'ko-KR'
  )}원 선택하면 예약 페이지로 이동합니다.`;
  return itemDetailMessageForATUser;
};
```
여행 상세 정보 메시지를 만드는 `getItemDetailMessage`를 구현했고, 
```tsx
<button
  key={index}
  className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
  // onClick과 같은 사용자와 상호작용을 하기 위한 태그는 div보다는 button이 적합.
  onClick={() => handleCardClick(option.link)}
  aria-label={itemDetailMessageForATUser}
>
```
버튼 태그에서 활용할 수 있도록 했습니다.

## 2 페이지 접근성 개선

- [x] 페이지를 하나의 문서로 읽을 수 있어야 합니다.
  - [x] 페이지에 적절한 제목(title)을 제공하세요. 제목은 페이지의 주요 내용을 간결하게 설명해야 합니다.

```html
<title>React App</title>
```
```html
<title>AllY HARRY AIRLINE</title>
```
html -> head -> title 태그를 수정했습니다. 

  - [x] 페이지의 주요 영역을 시맨틱 태그를 사용해 명확히 구분해 주세요

`App.tsx` 에서 header, main, footer로 페이지의 구조를 시멘틱하게 개선했습니다.
```tsx
<header className={styles.header}>
  <h1 className={`${styles.title} heading-1-text`}>A11Y AIRLINE</h1>
  <p className="body-text">
    A11Y AIRLINE은 고객 여러분의 안전하고 쾌적한 여행을 위해 최선을 다하고 있습니다.
  </p>
</header>
<main id="main-content" className={styles.main}>
  <div className={styles.flightBooking}>
    <FlightBooking />
  </div>
  <div className={styles.travelSection}>
    <h2 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h2>
    <TravelSection />
  </div>
</main>
<footer className={styles.footer}>
  <p className="body-text">&copy; HARRY AIRLINE</p>
</footer>
```

  - [x] 헤딩을 논리적인 순서로 사용해 페이지 구조를 명확히 해주세요 

| 개선 전 | 개선 후 |
| --- | --- | 
| <img width="489" alt="image" src="https://github.com/user-attachments/assets/97f93748-e2cc-4197-9791-c0ffe4689f0b"> | <img width="506" alt="image" src="https://github.com/user-attachments/assets/b707806f-498d-429b-9457-e725a1c71246"> |

기존에는 하나의 페이지에 h1 태그가 두개 있었습니다. [MDN - Heading-Elements 사용일람](https://developer.mozilla.org/ko/docs/Web/HTML/Element/Heading_Elements#%EC%82%AC%EC%9A%A9_%EC%9D%BC%EB%9E%8C)에서 확인할 수 있듯 하나의 페이지에는 하나의 h1 태그만 있어야 합니다. 이를 개선해서 논리적인 순서로 페이지의 구조를 명확히 했습니다.

- [x] 키보드 사용자를 위해 페이지 최상단에 '본문으로 바로가기' 링크를 제공해 반복되는 메뉴를 건너뛸 수 있게 해주세요

<img width="494" alt="image" src="https://github.com/user-attachments/assets/4e1ad91d-227c-4915-af5a-2625d5b73782">

이미지에서 확인할 수 있듯, 본문으로 바로갈 수 있는 탭을 구현했습니다.


## 🧐 우리 팀의 접근성 체크리스트

<!--
우리 서비스에서 이런 부분의 접근성은 챙겨봐야겠다! 하는 체크리스트 v1을 만들고, 리뷰어와 의견을 나눠보세요
- 우리 팀 서비스에서 가장 중요하고 자주 사용되는 기능 플로우 1개를 선택하고 간단히 나열해 주세요 (예: 로그인 → 상품 검색 → 상품 선택 → 장바구니 추가 → 결제)
- 해당 플로우의 각 단계에 대해 다음 질문을 생각해 보세요.
  - 1. 화면을 볼 수 없는 사용자가 이 단계를 완료할 수 있는가?
  - 2. 이 단계에서 제공하는 정보나 지시 사항이 모든 사용자에게 명확한가?
- 질문에 대해 팀원들과 의견을 나눠본 것을 바탕으로, 우리 팀만의 접근성 체크리스트 v1을 만들고 리뷰어와 의견을 나눠보세요. (예: "모든 이미지에 적절한 대체 텍스트가 제공되는가?")
-->

현재 저희 서비스가 접근성을 개선하려고 하는 기능 플로우는 다음과 같습니다.

약속에 초대 받은 사용자는 약속 시간 조회 페이지로 입장 -> 다른 약속 참여자들의 약속 시간 조회 -> 약속에 참여할 수 있는 시간 or 날짜를 선택

시간을 선택하는 경우, 드래그 기능을 제공합니다. 스크린 리더 사용자도 드래그 기능을 이용할 수 있도록 해주기 위한 방법이 생각나지 않아서 우선 조회만 할 수 있도록 개선해 보고자 합니다.

- 스크린 리더가 시간 테이블 UI를 읽을 수 있는가?
- 스크린 리더가 참여자 변경 탭의 의미를 전달해 줄 수 있는가?
- 시간 등록/수정 버튼을 읽어줄 수 있는가?
- 특정 날짜 or 시간을 클릭했을 때, 해당 시간을 선택한 참여자들을 읽어줄 수 있는가?
- 조회하려는 참여자가 변경되면, 참여자가 선택한 시간을 읽어줄 수 있는가?
- disabled된 날짜는 스크린 리더가 무시할 수 있는가?
- 스크린 리더 사용자가 날짜/시간 등록이 완료되었다는 것을 알려줄 수 있는가?
- 날짜를 선택할 때 해당 날짜가 어떤 날짜인지에 대한 정보를 스크린 리더가 읽어줄 수 있는가?
- 선택한 약속을 초기화 할 수 있는가?
