### PR TITLE
[항공사 웹사이트의 컴포넌트 접근성 높이기] 아르(홍성진) 미션 제출합니다 

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,15 +1,18 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="title" content="A11Y AIRLINE | 접근성 좋은 항공사" />
+    <meta
+      name="description"
+      content="고객 여러분의 안전하고 쾌적한 여행을 위해 최선을 다하는 A11Y AIRLINE입니다."
+    />
+    <title>A11Y AIRLINE | 접근성 좋은 항공사</title>
+  </head>
 
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>React App</title>
-</head>
-
-<body>
-  <div id="root"></div>
-  <script type="module" src="/src/main.tsx"></script>
-</body>
-
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "deploy": "npm run build && npx gh-pages -d dist"
   },
   "author": "woowacourse",
-  "homepage": "https://{username}.github.io/a11y-airline",
+  "homepage": "https://seongjinme.github.io/a11y-airline",
   "license": "MIT",
   "dependencies": {
     "react": "^18.3.1",

--- a/src/App.module.css
+++ b/src/App.module.css
@@ -9,6 +9,27 @@
   margin: 0 auto;
 }
 
+.skipToContentButton {
+  position: absolute;
+  background-color: #158dd2;
+  border: 0;
+  border-radius: 4px;
+  padding: 10px;
+  z-index: 1;
+
+  font-size: 16px;
+  color: #fff;
+  text-decoration: none;
+}
+
+.skipToContentButton:focus {
+  opacity: 1;
+}
+
+.skipToContentButton:not(:focus) {
+  opacity: 0;
+}
+
 .header {
   padding: 48px 24px 24px 24px;
 }

--- a/src/App.module.css
+++ b/src/App.module.css
@@ -30,11 +30,6 @@
   background-color: rgb(246, 246, 246);
 }
 
-.travelTitle {
-  font-size: 18px;
-  padding: 24px;
-}
-
 .footer {
   padding: 32px;
   background-color: white;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,8 +7,16 @@ import TravelSection from './components/TravelSection';
 function App() {
   return (
     <div className={styles.app}>
+      <a
+        type="button"
+        href="#banner-content"
+        aria-hidden="true"
+        className={styles.skipToContentButton}
+      >
+        본문으로 바로가기
+      </a>
       <Navigation />
-      <header className={styles.header}>
+      <header id="banner-content" className={styles.header}>
         <h1 className={`${styles.title} heading-1-text`}>A11Y AIRLINE</h1>
         <p className="body-text">
           A11Y AIRLINE은 고객 여러분의 안전하고 쾌적한 여행을 위해 최선을 다하고 있습니다.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,17 +2,13 @@ import styles from './App.module.css';
 import Navigation from './components/Navigation';
 import FlightBooking from './components/FlightBooking';
 import TravelSection from './components/TravelSection';
-// import PromotionModal from './components/PromotionModal';
+import PromotionModal from './components/PromotionModal';
 
 function App() {
   return (
     <div className={styles.app}>
-      <a
-        type="button"
-        href="#banner-content"
-        aria-hidden="true"
-        className={styles.skipToContentButton}
-      >
+      <PromotionModal />
+      <a type="button" href="#banner-content" className={styles.skipToContentButton}>
         본문으로 바로가기
       </a>
       <Navigation />
@@ -33,8 +29,6 @@ function App() {
       <footer className={styles.footer}>
         <p className="body-text">&copy; A11Y AIRLINE</p>
       </footer>
-      {/* 추가 CHALLENGE: 모달 포커스 트랩 */}
-      {/* <PromotionModal /> */}
     </div>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,24 +8,23 @@ function App() {
   return (
     <div className={styles.app}>
       <Navigation />
-      <div className={styles.header}>
+      <header className={styles.header}>
         <h1 className={`${styles.title} heading-1-text`}>A11Y AIRLINE</h1>
         <p className="body-text">
           A11Y AIRLINE은 고객 여러분의 안전하고 쾌적한 여행을 위해 최선을 다하고 있습니다.
         </p>
-      </div>
-      <div id="main-content" className={styles.main}>
+      </header>
+      <main id="main-content" className={styles.main}>
         <div className={styles.flightBooking}>
           <FlightBooking />
         </div>
         <div className={styles.travelSection}>
-          <h1 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h1>
           <TravelSection />
         </div>
-      </div>
-      <div className={styles.footer}>
+      </main>
+      <footer className={styles.footer}>
         <p className="body-text">&copy; A11Y AIRLINE</p>
-      </div>
+      </footer>
       {/* 추가 CHALLENGE: 모달 포커스 트랩 */}
       {/* <PromotionModal /> */}
     </div>

--- a/src/components/FlightBooking.tsx
+++ b/src/components/FlightBooking.tsx
@@ -35,27 +35,38 @@ const FlightBooking = () => {
   }, [adultCount]);
 
   return (
-    <div className={styles.flightBooking}>
+    <section className={styles.flightBooking}>
       <h2 className="heading-2-text">항공권 예매</h2>
       <div className={styles.passengerCount}>
         <div className={styles.passengerLabel}>
           <span className="body-text">성인</span>
           <div
+            role="tooltip"
             className={styles.helpIconWrapper}
             onMouseEnter={() => setShowTooltip(true)}
             onMouseLeave={() => setShowTooltip(false)}
+            aria-label={`승객 수 도움말: 최대 ${MAX_PASSENGERS}명까지 예약할 수 있습니다.`}
           >
-            <img src={helpIcon} alt="도움말" className={styles.helpIcon} />
-            {showTooltip && <div className={styles.tooltip}>최대 3명까지 예약할 수 있습니다</div>}
+            <img
+              src={helpIcon}
+              alt="승객 수 도움말"
+              area-hidden="true"
+              className={styles.helpIcon}
+            />
+            {showTooltip && (
+              <div className={styles.tooltip}>
+                {`최대 ${MAX_PASSENGERS}명까지 예약할 수 있습니다`}
+              </div>
+            )}
           </div>
         </div>
         <div className={styles.counter}>
-          <button className="button-text" onClick={decrementCount} aria-label="성인 승객 감소">
-            <img src={minus} alt="" />
+          <button type="button" className="button-text" onClick={decrementCount}>
+            <img src={minus} alt="성인 승객 감소" />
           </button>
           <span aria-live="polite">{adultCount}</span>
-          <button className="button-text" onClick={incrementCount} aria-label="성인 승객 증가">
-            <img src={plus} alt="" />
+          <button type="button" className="button-text" onClick={incrementCount}>
+            <img src={plus} alt="성인 승객 증가" />
           </button>
         </div>
       </div>
@@ -64,8 +75,10 @@ const FlightBooking = () => {
           {statusMessage}
         </div>
       )}
-      <button className={styles.searchButton}>항공편 검색</button>
-    </div>
+      <button type="button" className={styles.searchButton}>
+        항공편 검색
+      </button>
+    </section>
   );
 };
 

--- a/src/components/FlightBooking.tsx
+++ b/src/components/FlightBooking.tsx
@@ -41,9 +41,14 @@ const FlightBooking = () => {
         <div className={styles.passengerLabel}>
           <span className="body-text">성인</span>
           <div
+            role="tooltip"
             className={styles.helpIconWrapper}
+            tabIndex={0}
             onMouseEnter={() => setShowTooltip(true)}
             onMouseLeave={() => setShowTooltip(false)}
+            onFocus={() => setShowTooltip(true)}
+            onBlur={() => setShowTooltip(false)}
+            aria-label={`승객 수 도움말: 최대 ${MAX_PASSENGERS}명까지 예약할 수 있습니다.`}
           >
             <img
               src={helpIcon}
@@ -51,7 +56,6 @@ const FlightBooking = () => {
               aria-hidden="true"
               className={styles.helpIcon}
             />
-            <span className="visually-hidden">{`승객 수 도움말: 최대 ${MAX_PASSENGERS}명까지 예약할 수 있습니다.`}</span>
             {showTooltip && (
               <div className={styles.tooltip}>
                 {`최대 ${MAX_PASSENGERS}명까지 예약할 수 있습니다`}

--- a/src/components/FlightBooking.tsx
+++ b/src/components/FlightBooking.tsx
@@ -41,18 +41,17 @@ const FlightBooking = () => {
         <div className={styles.passengerLabel}>
           <span className="body-text">성인</span>
           <div
-            role="tooltip"
             className={styles.helpIconWrapper}
             onMouseEnter={() => setShowTooltip(true)}
             onMouseLeave={() => setShowTooltip(false)}
-            aria-label={`승객 수 도움말: 최대 ${MAX_PASSENGERS}명까지 예약할 수 있습니다.`}
           >
             <img
               src={helpIcon}
               alt="승객 수 도움말"
-              area-hidden="true"
+              aria-hidden="true"
               className={styles.helpIcon}
             />
+            <span className="visually-hidden">{`승객 수 도움말: 최대 ${MAX_PASSENGERS}명까지 예약할 수 있습니다.`}</span>
             {showTooltip && (
               <div className={styles.tooltip}>
                 {`최대 ${MAX_PASSENGERS}명까지 예약할 수 있습니다`}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -45,9 +45,9 @@ const Navigation = () => {
   };
 
   const renderNavItems = (items: NavItem[]) => (
-    <ul className={styles.navList}>
+    <ul role="menu" className={styles.navList}>
       {items.map((item, index) => (
-        <li key={index} className={styles.navItem}>
+        <li role="menuitem" key={index} className={styles.navItem}>
           <a href={item.link}>{item.title}</a>
           {item.subItems && renderNavItems(item.subItems)}
         </li>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -62,7 +62,7 @@ const Navigation = () => {
       <button
         className={styles.navToggle}
         onClick={toggleNav}
-        aria-label="메인 메뉴"
+        aria-label={isNavOpen ? '메인 메뉴 닫기' : '메인 메뉴 열기'}
         aria-expanded={isNavOpen}
       >
         {isNavOpen ? '닫기' : '메뉴'}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -59,7 +59,12 @@ const Navigation = () => {
 
   return (
     <>
-      <button className={styles.navToggle} onClick={toggleNav}>
+      <button
+        className={styles.navToggle}
+        onClick={toggleNav}
+        aria-label="메인 메뉴"
+        aria-expanded={isNavOpen}
+      >
         {isNavOpen ? '닫기' : '메뉴'}
       </button>
       <nav id="main-nav" className={`${styles.mainNav} ${isNavOpen ? styles.mainNavActive : ''}`}>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -47,8 +47,10 @@ const Navigation = () => {
   const renderNavItems = (items: NavItem[]) => (
     <ul role="menu" className={styles.navList}>
       {items.map((item, index) => (
-        <li role="menuitem" key={index} className={styles.navItem}>
-          <a href={item.link}>{item.title}</a>
+        <li key={index} className={styles.navItem}>
+          <a role="menuitem" href={item.link}>
+            {item.title}
+          </a>
           {item.subItems && renderNavItems(item.subItems)}
         </li>
       ))}

--- a/src/components/PromotionModal.tsx
+++ b/src/components/PromotionModal.tsx
@@ -85,7 +85,11 @@ const PromotionModal = () => {
       role="dialog"
       aria-modal="true"
       aria-label="A11Y AIRLINE 서비스 안내 모달"
+      aria-live="assertive"
     >
+      <div className="visually-hidden">
+        서비스 안내 모달이 열려 있습니다. 닫기 버튼으로 이 모달을 닫을 수 있습니다.
+      </div>
       <div className={styles.modalBackdrop} onClick={closeModal} aria-hidden="true"></div>
       <div className={styles.modalContainer}>
         <div className={styles.modalContent}>

--- a/src/components/PromotionModal.tsx
+++ b/src/components/PromotionModal.tsx
@@ -16,22 +16,39 @@ const PromotionModal = () => {
   }
 
   return (
-    <div className={styles.modal}>
-      <div className={styles.modalBackdrop} onClick={closeModal}></div>
+    <section
+      className={styles.modal}
+      role="dialog"
+      aria-modal="true"
+      aria-label="A11Y AIRLINE 서비스 안내 모달"
+    >
+      <div className={styles.modalBackdrop} onClick={closeModal} aria-hidden="true"></div>
       <div className={styles.modalContainer}>
         <div className={styles.modalContent}>
-          <h2 className={`${styles.modalTitle} heading-2-text`}>여행할 땐 A11Y AIRLINE 앱</h2>
-          <p className={`${styles.modalDescription} body-text`}>
-            체크인, 탑승권 저장, 수하물 알림까지
-            <br />- 앱으로 더욱 편하게 여행하세요!
-          </p>
-          <button className={`${styles.modalActionButton} button-text`}>앱에서 열기</button>
-          <button className={`${styles.modalCloseButton} heading-2-text`} onClick={closeModal}>
-            <img src={close} />
-          </button>
+          <header>
+            <h2 className={`${styles.modalTitle} heading-2-text`}>여행할 땐 A11Y AIRLINE 앱</h2>
+          </header>
+          <main>
+            <p className={`${styles.modalDescription} body-text`}>
+              체크인, 탑승권 저장, 수하물 알림까지
+              <br />- 앱으로 더욱 편하게 여행하세요!
+            </p>
+            <button type="button" className={`${styles.modalActionButton} button-text`}>
+              앱에서 열기
+            </button>
+          </main>
+          <footer>
+            <button
+              type="button"
+              className={`${styles.modalCloseButton} heading-2-text`}
+              onClick={closeModal}
+            >
+              <img src={close} alt="모달 닫기" />
+            </button>
+          </footer>
         </div>
       </div>
-    </div>
+    </section>
   );
 };
 

--- a/src/components/PromotionModal.tsx
+++ b/src/components/PromotionModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import close from '../assets/close.svg';
 
@@ -10,6 +10,16 @@ const PromotionModal = () => {
   const closeModal = () => {
     setIsOpen(false);
   };
+
+  useEffect(() => {
+    const handleCloseModalWithKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') closeModal();
+    };
+
+    if (isOpen) document.addEventListener('keydown', handleCloseModalWithKey);
+
+    return () => document.removeEventListener('keydown', handleCloseModalWithKey);
+  }, [isOpen]);
 
   if (!isOpen) {
     return null;

--- a/src/components/TravelSection.module.css
+++ b/src/components/TravelSection.module.css
@@ -3,6 +3,11 @@
   padding-bottom: 32px;
 }
 
+.travelSectionTitle {
+  font-size: 18px;
+  padding: 24px;
+}
+
 .carousel {
   position: relative;
   overflow: hidden;

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -81,13 +81,13 @@ const TravelSection = () => {
             aria-label={getTravelDescription()}
             aria-live="polite"
           >
-            <div aria-hidden="true">
+            <figure aria-hidden="true">
               <img
                 alt={`${option.departure}-${option.destination} 여행 상품 이미지`}
                 src={option.image}
                 className={styles.cardImage}
               />
-              <div className={styles.cardContent}>
+              <figcaption className={styles.cardContent}>
                 <h3 className={`${styles.cardTitle} heading-3-text`}>
                   {option.departure} - {option.destination}
                 </h3>
@@ -95,8 +95,8 @@ const TravelSection = () => {
                 <p className={`${styles.cardPrice} body-text`}>
                   KRW {option.price.toLocaleString()}
                 </p>
-              </div>
-            </div>
+              </figcaption>
+            </figure>
           </div>
         ))}
       </section>

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -71,7 +71,7 @@ const TravelSection = () => {
   return (
     <section className={styles.travelSection}>
       <h2 className={`${styles.travelSectionTitle} heading-2-text`}>지금 떠나기 좋은 여행</h2>
-      <section className={styles.carousel}>
+      <div className={styles.carousel}>
         {travelOptions.map((option, index) => (
           <div
             key={index}
@@ -99,7 +99,7 @@ const TravelSection = () => {
             </figure>
           </div>
         ))}
-      </section>
+      </div>
       <button
         type="button"
         className={`${styles.navButton} ${styles.navButtonPrev}`}

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -61,7 +61,6 @@ const TravelSection = () => {
 
   const getTravelDescription = () => {
     const { departure, destination, price, type } = travelOptions[currentIndex];
-
     return `
       ${travelOptions.length}개의 여행 상품 중 ${currentIndex + 1}번째입니다.
       ${departure}에서 ${destination}로 향하는 ${type} 상품으로, 가격은 ${price}원입니다.
@@ -79,8 +78,9 @@ const TravelSection = () => {
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
             onClick={() => handleCardClick(option.link)}
             role="button"
+            aria-label={getTravelDescription()}
+            aria-live="polite"
           >
-            <p className="visually-hidden">{getTravelDescription()}</p>
             <div aria-hidden="true">
               <img
                 alt={`${option.departure}-${option.destination} 여행 상품 이미지`}

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -73,7 +73,7 @@ const TravelSection = () => {
       <h2 className={`${styles.travelSectionTitle} heading-2-text`}>지금 떠나기 좋은 여행</h2>
       <section className={styles.carousel}>
         {travelOptions.map((option, index) => (
-          <article
+          <div
             key={index}
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
             onClick={() => handleCardClick(option.link)}
@@ -97,7 +97,7 @@ const TravelSection = () => {
                 </p>
               </div>
             </div>
-          </article>
+          </div>
         ))}
       </section>
       <button

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -59,6 +59,12 @@ const TravelSection = () => {
     window.open(link, '_blank', 'noopener,noreferrer');
   };
 
+  const handleCardKeyDown = (event: React.KeyboardEvent<HTMLDivElement>, link: string) => {
+    if (event.key === 'Enter') {
+      window.open(link, '_blank', 'noopener,noreferrer');
+    }
+  };
+
   const getTravelDescription = () => {
     const { departure, destination, price, type } = travelOptions[currentIndex];
     return `
@@ -75,8 +81,10 @@ const TravelSection = () => {
         {travelOptions.map((option, index) => (
           <div
             key={index}
+            tabIndex={0}
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
             onClick={() => handleCardClick(option.link)}
+            onKeyDown={(event) => handleCardKeyDown(event, option.link)}
             role="button"
             aria-label={getTravelDescription()}
             aria-live="polite"

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -59,32 +59,60 @@ const TravelSection = () => {
     window.open(link, '_blank', 'noopener,noreferrer');
   };
 
+  const getTravelDescription = () => {
+    const { departure, destination, price, type } = travelOptions[currentIndex];
+
+    return `
+      ${travelOptions.length}개의 여행 상품 중 ${currentIndex + 1}번째입니다.
+      ${departure}에서 ${destination}로 향하는 ${type} 상품으로, 가격은 ${price}원입니다.
+      선택하시면 예약 페이지로 이동합니다.
+    `;
+  };
+
   return (
     <section className={styles.travelSection}>
       <h2 className={`${styles.travelSectionTitle} heading-2-text`}>지금 떠나기 좋은 여행</h2>
-      <button className={`${styles.navButton} ${styles.navButtonPrev}`} onClick={prevTravel}>
-        <img src={chevronLeft} className={styles.navButtonIcon} />
-      </button>
       <section className={styles.carousel}>
         {travelOptions.map((option, index) => (
           <article
             key={index}
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
             onClick={() => handleCardClick(option.link)}
+            role="button"
           >
-            <img src={option.image} className={styles.cardImage} />
-            <div className={styles.cardContent}>
-              <h3 className={`${styles.cardTitle} heading-3-text`}>
-                {option.departure} - {option.destination}
-              </h3>
-              <p className={`${styles.cardType} body-text`}>{option.type}</p>
-              <p className={`${styles.cardPrice} body-text`}>KRW {option.price.toLocaleString()}</p>
+            <p className="visually-hidden">{getTravelDescription()}</p>
+            <div aria-hidden="true">
+              <img
+                alt={`${option.departure}-${option.destination} 여행 상품 이미지`}
+                src={option.image}
+                className={styles.cardImage}
+              />
+              <div className={styles.cardContent}>
+                <h3 className={`${styles.cardTitle} heading-3-text`}>
+                  {option.departure} - {option.destination}
+                </h3>
+                <p className={`${styles.cardType} body-text`}>{option.type}</p>
+                <p className={`${styles.cardPrice} body-text`}>
+                  KRW {option.price.toLocaleString()}
+                </p>
+              </div>
             </div>
           </article>
         ))}
       </section>
-      <button className={`${styles.navButton} ${styles.navButtonNext}`} onClick={nextTravel}>
-        <img src={chevronRight} className={styles.navButtonIcon} />
+      <button
+        type="button"
+        className={`${styles.navButton} ${styles.navButtonPrev}`}
+        onClick={prevTravel}
+      >
+        <img src={chevronLeft} alt="이전 상품으로 이동" className={styles.navButtonIcon} />
+      </button>
+      <button
+        type="button"
+        className={`${styles.navButton} ${styles.navButtonNext}`}
+        onClick={nextTravel}
+      >
+        <img src={chevronRight} alt="다음 상품으로 이동" className={styles.navButtonIcon} />
       </button>
     </section>
   );

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -60,32 +60,33 @@ const TravelSection = () => {
   };
 
   return (
-    <div className={styles.travelSection}>
+    <section className={styles.travelSection}>
+      <h2 className={`${styles.travelSectionTitle} heading-2-text`}>지금 떠나기 좋은 여행</h2>
       <button className={`${styles.navButton} ${styles.navButtonPrev}`} onClick={prevTravel}>
         <img src={chevronLeft} className={styles.navButtonIcon} />
       </button>
-      <div className={styles.carousel}>
+      <section className={styles.carousel}>
         {travelOptions.map((option, index) => (
-          <div
+          <article
             key={index}
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
             onClick={() => handleCardClick(option.link)}
           >
             <img src={option.image} className={styles.cardImage} />
             <div className={styles.cardContent}>
-              <p className={`${styles.cardTitle} heading-3-text`}>
+              <h3 className={`${styles.cardTitle} heading-3-text`}>
                 {option.departure} - {option.destination}
-              </p>
+              </h3>
               <p className={`${styles.cardType} body-text`}>{option.type}</p>
               <p className={`${styles.cardPrice} body-text`}>KRW {option.price.toLocaleString()}</p>
             </div>
-          </div>
+          </article>
         ))}
-      </div>
+      </section>
       <button className={`${styles.navButton} ${styles.navButtonNext}`} onClick={nextTravel}>
         <img src={chevronRight} className={styles.navButtonIcon} />
       </button>
-    </div>
+    </section>
   );
 };
 


### PR DESCRIPTION
썬데이 안녕하세요. 아르입니다. 반가워요. 이번 미션 잘 부탁드릴게요 🙏 

## 🔥 결과

### 배포한 페이지 접근 경로(GitHub Pages)
- https://seongjinme.github.io/a11y-airline/

### 스크린 리더 화면 녹화 영상
#### before
https://github.com/user-attachments/assets/5be2338c-41fd-47a8-af6a-30abb1402193

#### after
https://github.com/user-attachments/assets/f209da09-f19c-4252-bcd8-81542b337b1c

## ✅ 개선 작업 목록

### 1 컴포넌트 접근성 개선 - 이미지 캐로셀

- [x] 스크린 리더가 캐로셀의 전체 아이템 수를 읽을 수 있어야 합니다.
- [x] 스크린 리더가 이미지 캐로셀 내 각 아이템 정보를 읽을 수 있어야 합니다.
  - [x] 여행지, 좌석 유형, 가격 정보를 한번에 읽을 수 있어야 합니다.
  - [x] 이전/다음 아이템으로 이동하고 현재 보이는 아이템의 정보를 읽을 수 있어야 합니다.
- [x] 각 아이템을 선택하면 각각에 맞는 링크로 이동할 수 있어야 합니다.

#### 개선 방법
- 스크린 리더가 캐로셀 섹션의 제목(`h2`) 요소 다음으로 여행 상품에 대한 정보를 곧바로 읽을 수 있도록 코드 구조를 수정했어요. 
- `aria-live` 속성을 이용해서, 이전/다음으로 이동했을 때 현재 보이는 상품의 정보를 읽어주도록 했어요.
- 상품 정보에 대한 내용만 `aria-label`로 처리하고, 버튼 요소에 대해서는 `img`의 `alt` 요소로 텍스트를 대체하여 시멘틱 구조를 최대한 활용했어요.
  - [feat(TravelSection): 캐로셀에 포함된 각 상품 설명을 올바른 순서로 읽을 수 있도록 개선](https://github.com/woowacourse/a11y-airline/commit/60c2934d926eab0514e048f6f54f179442315826)
- 키보드로도 캐로셀 기능을 이용할 수 있도록 개선했어요.
  - [feat(TravelSection): 여행 상품 캐로셀에 키보드 이벤트 추가](https://github.com/woowacourse/a11y-airline/commit/82ec5b5e34b37d4e065a7cb7d28c9525df12c7ad)

### 2 페이지 접근성 개선

- [x] 페이지를 하나의 문서로 읽을 수 있어야 합니다.
  - [x] 페이지에 적절한 제목(title)을 제공하세요. 제목은 페이지의 주요 내용을 간결하게 설명해야 합니다.
  - [x] 페이지의 주요 영역을 시맨틱 태그를 사용해 명확히 구분해 주세요
  - [x] 헤딩을 논리적인 순서로 사용해 페이지 구조를 명확히 해주세요
- [x] 키보드 사용자를 위해 페이지 최상단에 '본문으로 바로가기' 링크를 제공해 반복되는 메뉴를 건너뛸 수 있게 해주세요

#### 개선 방법

- 애플리케이션 전체에 Meta 태그 및 `section`, `header`, `main`, `footer`, `figure` 등 시멘틱 HTML 요소들을 사용했어요.
  - [feat: meta 태그 및 title 요소 추가](https://github.com/woowacourse/a11y-airline/commit/342c254c4de31418eace74f6ce62e3ecaec32155)
  - [refactor: App, TravelSection 컴포넌트에 시멘틱 요소 적용](https://github.com/woowacourse/a11y-airline/commit/e8299ab222b3f3be5f8e4a2278a47b11568dfe0c)
  - [feat(PromotionModal): 모달에 시멘틱 구조 및 음성 지원 정보 적용](https://github.com/woowacourse/a11y-airline/commit/bb79eb62283c87a2743e00edc65595253073b11b)

- 애플리케이션 첫 화면에서 탭 포커스로 접근 가능한 '본문으로 바로가기' 버튼을 구현했어요. 별도의 스크립트 없이 CSS로만 구현했습니다.
  - [feat(PromotionModal): 모달에 시멘틱 구조 및 음성 지원 정보 적용](https://github.com/woowacourse/a11y-airline/commit/bb79eb62283c87a2743e00edc65595253073b11b)

#### 참고 이미지: WAE Structure 스크린샷

<img width="365" alt="image" src="https://github.com/user-attachments/assets/243ec658-0785-45df-b5b2-ef939cf5d655">

### 3 팝업 모달 포커스 트랩

- [x] 스크린 리더로 진입했을 때에도 현재 팝업이 떴다는 것을 인지할 수 있게 개선해 주세요.
- [x] 팝업이 열려있는 동안에는 포커스 이동이 팝업 내에서만 이루어져야 합니다.
- [x] 스크린 리더로 팝업을 닫을 수 있어야 합니다.
- [x] 키보드 접근성을 함께 고려합니다. (키보드만으로도 팝업으로 바로 진입해서 팝업을 닫을 수 있어야 합니다)

#### 개선 방법

- 모달 컴포넌트에 시멘틱 구조를 적용하고, `aria-modal`과 `role=dialog` 속성을 이용해서 사용자에게 이 요소가 모달 요소임을 명료하게 드러내도록 수정했어요.
  - [feat(PromotionModal): 모달에 시멘틱 구조 및 음성 지원 정보 적용](https://github.com/woowacourse/a11y-airline/commit/bb79eb62283c87a2743e00edc65595253073b11b)
- App 컴포넌트 내부의 코드 구조를 변경해서, 팝업 모달이 Focus 순서에서 우선하도록 변경했어요.
  - [refactor(App): 모달 추가 및 DOM 구조상 위치 변경](https://github.com/woowacourse/a11y-airline/commit/7c786c5fd9c65d984a1fb11f67a6c969efb05462)
- `useRef`와 `useEffect`, 그리고 `document.activeElement`를 이용하여 포커스 트랩을 구현했어요. 이를 통해 모달이 열려있을 때, 키보드만으로 팝업 내부의 버튼을 오가며 팝업을 닫을 수 있도록 구현했어요.
  - [feat(PromotionModal): 모달 오픈시 탭 포커스 이동을 모달 내부로 한정하도록 구현](https://github.com/woowacourse/a11y-airline/pull/136/commits/a754c24e492888fbd87d843b5bb54ad79cf602fa)
- 또한 모달을 ESC 키로 닫을 수 있도록 했어요.
  - [feat(PromotionModal): ESC키로 닫는 기능 구현](https://github.com/woowacourse/a11y-airline/commit/ceacc6688af0b51f63aa296ba74864c6d35d85ca)

#### 참고 영상

https://github.com/user-attachments/assets/c1b115fd-118c-4075-bc08-b36ea64436dc

## 🧐 우리 팀의 접근성 체크리스트
### '크루루' 소개
- 운영 서버용 링크 : https://www.cruru.kr/
- 제가 속한 '크루루' 팀은 채용 관리 시스템(ATS) '크루루'를 만들고 있습니다. 리크루팅 업무 플랫폼으로서, 지원자 및 공고 관리에 특화된 서비스랍니다.

### '크루루'의 핵심 기능
1. 지원자 현황 대시보드
2. 신규 공고 및 지원서 생성 화면
3. (지원자 입장에서의) 공고 조회 및 지원 화면

### '크루루'의 접근성 개선이 필요한 최우선 기능 플로우

'크루루'에서 가장 많은, 불특정 다수의 이용자들이 이용할 것으로 예상되는 기능은 '(지원자 입장에서의) 공고 조회 및 지원 기능'이에요. 그래서 저희는 이 기능에 대한 접근성 개선을 1차적으로 진행하기로 했습니다.

- 기능의 플로우는 매우 간단합니다. "공고 상세 탭" -> "지원서 작성 탭" -> "지원서 제출 화면"으로 이루어져 있어요.
- 이러한 플로우에 기초하여, 저희는 오늘 강의 시간에 아래와 같은 우선순위 매트릭스를 만들었어요.
- 아래 내용을 살펴보시고, 혹시 놓치거나 간과한 부분은 없을지, 보다 더 발전시킬 만한 포인트가 있을지 간단히 의견을 부탁드릴게요. 🙏 

### '크루루'팀의 접근성 체크리스트 우선순위 매트릭스
<img width="992" alt="image" src="https://github.com/user-attachments/assets/2a83ca1d-ea89-4dff-aa12-05299208b222">