### PR TITLE
[항공사 웹사이트의 컴포넌트 접근성 높이기] 해삐(박소희) 미션 제출합니다 

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,15 +1,13 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ally-airline</title>
+  </head>
 
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>React App</title>
-</head>
-
-<body>
-  <div id="root"></div>
-  <script type="module" src="/src/main.tsx"></script>
-</body>
-
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>a11y-airline</title>
+    <meta
+      name="description"
+      content="a11y-airline은 누구나 쉽고 편리하게 항공권을 예매할 수 있도록 접근성을 강화한 항공사 웹사이트입니다."
+    />
   </head>
 
   <body>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>ally-airline</title>
+    <title>a11y-airline</title>
   </head>
 
   <body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-visually-hidden": "^1.2.3",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -911,85 +910,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@radix-ui/react-compose-refs": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
-      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-visually-hidden": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz",
-      "integrity": "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-primitive": "2.1.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.21.0.tgz",
@@ -1249,13 +1169,13 @@
       "version": "15.7.12",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
       "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/@types/react": {
       "version": "18.3.3",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
       "integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -1265,7 +1185,7 @@
       "version": "18.3.0",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
       "integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -1740,7 +1660,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/debug": {
       "version": "4.3.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
+        "@radix-ui/react-visually-hidden": "^1.2.3",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -910,6 +911,85 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz",
+      "integrity": "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.21.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.21.0.tgz",
@@ -1169,13 +1249,13 @@
       "version": "15.7.12",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
       "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/react": {
       "version": "18.3.3",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
       "integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -1185,7 +1265,7 @@
       "version": "18.3.0",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
       "integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -1660,7 +1740,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/debug": {
       "version": "4.3.6",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "deploy": "npm run build && npx gh-pages -d dist"
   },
   "author": "woowacourse",
-  "homepage": "https://{username}.github.io/a11y-airline",
+  "homepage": "https://thgml05.github.io/a11y-airline",
   "license": "MIT",
   "dependencies": {
     "react": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "homepage": "https://thgml05.github.io/a11y-airline",
   "license": "MIT",
   "dependencies": {
-    "@radix-ui/react-visually-hidden": "^1.2.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "homepage": "https://thgml05.github.io/a11y-airline",
   "license": "MIT",
   "dependencies": {
+    "@radix-ui/react-visually-hidden": "^1.2.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/src/App.module.css
+++ b/src/App.module.css
@@ -9,6 +9,20 @@
   margin: 0 auto;
 }
 
+.skipLink {
+  position: absolute;
+  left: -9999px;
+}
+
+.skipLink:focus {
+  left: 0;
+  top: 0;
+  background: black;
+  color: white;
+  padding: 8px;
+  z-index: 1000;
+}
+
 .header {
   padding: 48px 24px 24px 24px;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,24 +8,24 @@ function App() {
   return (
     <div className={styles.app}>
       <Navigation />
-      <div className={styles.header}>
+      <header className={styles.header}>
         <h1 className={`${styles.title} heading-1-text`}>A11Y AIRLINE</h1>
         <p className="body-text">
           A11Y AIRLINE은 고객 여러분의 안전하고 쾌적한 여행을 위해 최선을 다하고 있습니다.
         </p>
-      </div>
-      <div id="main-content" className={styles.main}>
-        <div className={styles.flightBooking}>
+      </header>
+      <main id="main-content" className={styles.main}>
+        <section className={styles.flightBooking}>
           <FlightBooking />
-        </div>
-        <div className={styles.travelSection}>
-          <h1 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h1>
+        </section>
+        <section className={styles.travelSection}>
+          <h2 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h2>
           <TravelSection />
-        </div>
-      </div>
-      <div className={styles.footer}>
+        </section>
+      </main>
+      <footer className={styles.footer}>
         <p className="body-text">&copy; A11Y AIRLINE</p>
-      </div>
+      </footer>
       {/* 추가 CHALLENGE: 모달 포커스 트랩 */}
       {/* <PromotionModal /> */}
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,9 @@ import TravelSection from './components/TravelSection';
 function App() {
   return (
     <div className={styles.app}>
+      <a href="#main-content" className={styles.skipLink}>
+        본문으로 바로가기
+      </a>
       <Navigation />
       <header className={styles.header}>
         <h1 className={`${styles.title} heading-1-text`}>A11Y AIRLINE</h1>

--- a/src/components/FlightBooking.tsx
+++ b/src/components/FlightBooking.tsx
@@ -47,7 +47,7 @@ const FlightBooking = () => {
           >
             <img
               src={helpIcon}
-              alt="도움말"
+              alt="도움말 아이콘"
               className={styles.helpIcon}
               aria-label="최대 3명까지 예약할 수 있습니다"
             />
@@ -56,11 +56,11 @@ const FlightBooking = () => {
         </div>
         <div className={styles.counter}>
           <button className="button-text" onClick={decrementCount} aria-label="성인 승객 감소">
-            <img src={minus} />
+            <img src={minus} alt="마이너스 아이콘" />
           </button>
           <span aria-live="polite">{adultCount}</span>
           <button className="button-text" onClick={incrementCount} aria-label="성인 승객 증가">
-            <img src={plus} />
+            <img src={plus} alt="플러스 아이콘" />
           </button>
         </div>
       </div>

--- a/src/components/FlightBooking.tsx
+++ b/src/components/FlightBooking.tsx
@@ -45,17 +45,22 @@ const FlightBooking = () => {
             onMouseEnter={() => setShowTooltip(true)}
             onMouseLeave={() => setShowTooltip(false)}
           >
-            <img src={helpIcon} alt="도움말" className={styles.helpIcon} />
+            <img
+              src={helpIcon}
+              alt="도움말"
+              className={styles.helpIcon}
+              aria-label="도움말, 최대 3명까지 예약할 수 있습니다"
+            />
             {showTooltip && <div className={styles.tooltip}>최대 3명까지 예약할 수 있습니다</div>}
           </div>
         </div>
         <div className={styles.counter}>
           <button className="button-text" onClick={decrementCount} aria-label="성인 승객 감소">
-            <img src={minus} alt="" />
+            <img src={minus} />
           </button>
           <span aria-live="polite">{adultCount}</span>
           <button className="button-text" onClick={incrementCount} aria-label="성인 승객 증가">
-            <img src={plus} alt="" />
+            <img src={plus} />
           </button>
         </div>
       </div>

--- a/src/components/FlightBooking.tsx
+++ b/src/components/FlightBooking.tsx
@@ -49,7 +49,7 @@ const FlightBooking = () => {
               src={helpIcon}
               alt="도움말"
               className={styles.helpIcon}
-              aria-label="도움말, 최대 3명까지 예약할 수 있습니다"
+              aria-label="최대 3명까지 예약할 수 있습니다"
             />
             {showTooltip && <div className={styles.tooltip}>최대 3명까지 예약할 수 있습니다</div>}
           </div>

--- a/src/components/FlightBooking.tsx
+++ b/src/components/FlightBooking.tsx
@@ -47,7 +47,7 @@ const FlightBooking = () => {
           >
             <img
               src={helpIcon}
-              alt="도움말 아이콘"
+              alt=""
               className={styles.helpIcon}
               aria-label="최대 3명까지 예약할 수 있습니다"
             />
@@ -56,11 +56,11 @@ const FlightBooking = () => {
         </div>
         <div className={styles.counter}>
           <button className="button-text" onClick={decrementCount} aria-label="성인 승객 감소">
-            <img src={minus} alt="마이너스 아이콘" />
+            <img src={minus} alt="" />
           </button>
           <span aria-live="polite">{adultCount}</span>
           <button className="button-text" onClick={incrementCount} aria-label="성인 승객 증가">
-            <img src={plus} alt="플러스 아이콘" />
+            <img src={plus} alt="" />
           </button>
         </div>
       </div>

--- a/src/components/TravelSection.module.css
+++ b/src/components/TravelSection.module.css
@@ -86,3 +86,15 @@
   width: 24px;
   height: 24px;
 }
+
+.visuallyHidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/src/components/TravelSection.module.css
+++ b/src/components/TravelSection.module.css
@@ -86,15 +86,3 @@
   width: 24px;
   height: 24px;
 }
-
-.visuallyHidden {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
-}

--- a/src/components/TravelSection.module.css
+++ b/src/components/TravelSection.module.css
@@ -17,6 +17,9 @@
   display: none;
   width: 100%;
   height: 246px;
+  padding: 0;
+  border: none;
+  text-align: left;
 }
 
 .cardActive {

--- a/src/components/TravelSection.module.css
+++ b/src/components/TravelSection.module.css
@@ -41,7 +41,7 @@
   right: 0;
   bottom: 0;
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.9) 26%, rgba(255, 255, 255, 0) 100%);
-  padding: 24px 16px;
+  padding: 24px 25px;
 }
 
 .cardTitle {
@@ -77,12 +77,14 @@
   left: 0;
   border-radius: 0 40px 40px 0;
   padding-left: 15px;
+  width: 40px;
 }
 
 .navButtonNext {
   right: 0;
   border-radius: 40px 0 0 40px;
   padding-right: 15px;
+  width: 40px;
 }
 
 .navButtonIcon {

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -85,8 +85,18 @@ const TravelSection = () => {
             </div>
           </div>
         ))}
-      </div>
-      <button className={`${styles.navButton} ${styles.navButtonNext}`} onClick={nextTravel}>
+      <button
+        className={`${styles.navButton} ${styles.navButtonPrev}`}
+        onClick={prevTravel}
+        aria-label="이전 여행 상품"
+      >
+        <img src={chevronLeft} className={styles.navButtonIcon} />
+      </button>
+      <button
+        className={`${styles.navButton} ${styles.navButtonNext}`}
+        onClick={nextTravel}
+        aria-label="다음 여행 상품"
+      >
         <img src={chevronRight} className={styles.navButtonIcon} />
       </button>
     </div>

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -68,7 +68,7 @@ const TravelSection = () => {
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
             onClick={() => handleCardClick(option.link)}
             aria-live="polite"
-            aria-label={`${travelOptions.length}의 여행 상품 중 ${index + 1}번째 상품. ${
+            aria-label={`${travelOptions.length}개의 여행 상품 중 ${index + 1}번째 상품. ${
               option.departure
             } 출발 ${option.destination} 도착. ${
               option.type

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -71,6 +71,9 @@ const TravelSection = () => {
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
             onClick={() => handleCardClick(option.link)}
           >
+            <span className={styles.visuallyHidden}>{`세계 여행 상품 중 ${
+              index + 1
+            }번째 상품`}</span>
             <img src={option.image} className={styles.cardImage} />
             <div className={styles.cardContent}>
               <p className={`${styles.cardTitle} heading-3-text`}>

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -62,15 +62,15 @@ const TravelSection = () => {
 
   return (
     <div className={styles.travelSection}>
-      <button className={`${styles.navButton} ${styles.navButtonPrev}`} onClick={prevTravel}>
-        <img src={chevronLeft} className={styles.navButtonIcon} />
-      </button>
       <div className={styles.carousel}>
         {travelOptions.map((option, index) => (
-          <div
+          <button
             key={index}
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
             onClick={() => handleCardClick(option.link)}
+            aria-label={`${option.departure} 출발 ${option.destination} 도착, ${
+              option.type
+            }, 가격 ${option.price.toLocaleString()} 원. 선택하면 예약 페이지로 이동합니다.`}
           >
             <VisuallyHidden>{`${travelOptions.length}의 여행 상품 중 ${
               index + 1
@@ -83,22 +83,23 @@ const TravelSection = () => {
               <p className={`${styles.cardType} body-text`}>{option.type}</p>
               <p className={`${styles.cardPrice} body-text`}>KRW {option.price.toLocaleString()}</p>
             </div>
-          </div>
+          </button>
         ))}
-      <button
-        className={`${styles.navButton} ${styles.navButtonPrev}`}
-        onClick={prevTravel}
-        aria-label="이전 여행 상품"
-      >
-        <img src={chevronLeft} className={styles.navButtonIcon} />
-      </button>
-      <button
-        className={`${styles.navButton} ${styles.navButtonNext}`}
-        onClick={nextTravel}
-        aria-label="다음 여행 상품"
-      >
-        <img src={chevronRight} className={styles.navButtonIcon} />
-      </button>
+        <button
+          className={`${styles.navButton} ${styles.navButtonPrev}`}
+          onClick={prevTravel}
+          aria-label="이전 여행 상품"
+        >
+          <img src={chevronLeft} className={styles.navButtonIcon} />
+        </button>
+        <button
+          className={`${styles.navButton} ${styles.navButtonNext}`}
+          onClick={nextTravel}
+          aria-label="다음 여행 상품"
+        >
+          <img src={chevronRight} className={styles.navButtonIcon} />
+        </button>
+      </div>
     </div>
   );
 };

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
 
 import travelItem01 from '../assets/travel-item-01.png';
 import travelItem02 from '../assets/travel-item-02.png';
@@ -71,9 +72,9 @@ const TravelSection = () => {
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
             onClick={() => handleCardClick(option.link)}
           >
-            <span className={styles.visuallyHidden}>{`세계 여행 상품 중 ${
+            <VisuallyHidden>{`${travelOptions.length}의 여행 상품 중 ${
               index + 1
-            }번째 상품`}</span>
+            }번째 상품`}</VisuallyHidden>
             <img src={option.image} className={styles.cardImage} />
             <div className={styles.cardContent}>
               <p className={`${styles.cardTitle} heading-3-text`}>

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -74,7 +74,11 @@ const TravelSection = () => {
               option.type
             }. 가격 ${option.price.toLocaleString()} 원. 선택하면 예약 페이지로 이동합니다.`}
           >
-            <img src={option.image} className={styles.cardImage} />
+            <img
+              src={option.image}
+              className={styles.cardImage}
+              alt={`${option.destination} 이미지`}
+            />
             <div className={styles.cardContent}>
               <p className={`${styles.cardTitle} heading-3-text`}>
                 {option.departure} - {option.destination}
@@ -89,14 +93,14 @@ const TravelSection = () => {
           onClick={prevTravel}
           aria-label="이전 여행 상품"
         >
-          <img src={chevronLeft} className={styles.navButtonIcon} />
+          <img src={chevronLeft} className={styles.navButtonIcon} alt="다음 화살표 아이콘" />
         </button>
         <button
           className={`${styles.navButton} ${styles.navButtonNext}`}
           onClick={nextTravel}
           aria-label="다음 여행 상품"
         >
-          <img src={chevronRight} className={styles.navButtonIcon} />
+          <img src={chevronRight} className={styles.navButtonIcon} alt="이전 화살표 아이콘" />
         </button>
       </div>
     </div>

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -93,14 +93,14 @@ const TravelSection = () => {
           onClick={prevTravel}
           aria-label="이전 여행 상품"
         >
-          <img src={chevronLeft} className={styles.navButtonIcon} alt="다음 화살표 아이콘" />
+          <img src={chevronLeft} className={styles.navButtonIcon} />
         </button>
         <button
           className={`${styles.navButton} ${styles.navButtonNext}`}
           onClick={nextTravel}
           aria-label="다음 여행 상품"
         >
-          <img src={chevronRight} className={styles.navButtonIcon} alt="이전 화살표 아이콘" />
+          <img src={chevronRight} className={styles.navButtonIcon} />
         </button>
       </div>
     </div>

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -61,17 +61,18 @@ const TravelSection = () => {
 
   return (
     <div className={styles.travelSection}>
-      <div className={styles.carousel} aria-live="polite">
+      <div className={styles.carousel}>
         {travelOptions.map((option, index) => (
           <button
             key={index}
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
             onClick={() => handleCardClick(option.link)}
-            aria-label={`${travelOptions.length}의 여행 상품 중 ${index + 1}번째 상품, ${
+            aria-live="polite"
+            aria-label={`${travelOptions.length}의 여행 상품 중 ${index + 1}번째 상품. ${
               option.departure
-            } 출발 ${option.destination} 도착, ${
+            } 출발 ${option.destination} 도착. ${
               option.type
-            }, 가격 ${option.price.toLocaleString()} 원. 선택하면 예약 페이지로 이동합니다.`}
+            }. 가격 ${option.price.toLocaleString()} 원. 선택하면 예약 페이지로 이동합니다.`}
           >
             <img src={option.image} className={styles.cardImage} />
             <div className={styles.cardContent}>

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
 
 import travelItem01 from '../assets/travel-item-01.png';
 import travelItem02 from '../assets/travel-item-02.png';
@@ -62,7 +61,7 @@ const TravelSection = () => {
 
   return (
     <div className={styles.travelSection}>
-      <div className={styles.carousel}>
+      <div className={styles.carousel} aria-live="polite">
         {travelOptions.map((option, index) => (
           <button
             key={index}
@@ -74,9 +73,6 @@ const TravelSection = () => {
               option.type
             }, 가격 ${option.price.toLocaleString()} 원. 선택하면 예약 페이지로 이동합니다.`}
           >
-            <VisuallyHidden>{`${travelOptions.length}의 여행 상품 중 ${
-              index + 1
-            }번째 상품`}</VisuallyHidden>
             <img src={option.image} className={styles.cardImage} />
             <div className={styles.cardContent}>
               <p className={`${styles.cardTitle} heading-3-text`}>

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -68,7 +68,9 @@ const TravelSection = () => {
             key={index}
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
             onClick={() => handleCardClick(option.link)}
-            aria-label={`${option.departure} 출발 ${option.destination} 도착, ${
+            aria-label={`${travelOptions.length}의 여행 상품 중 ${index + 1}번째 상품, ${
+              option.departure
+            } 출발 ${option.destination} 도착, ${
               option.type
             }, 가격 ${option.price.toLocaleString()} 원. 선택하면 예약 페이지로 이동합니다.`}
           >


### PR DESCRIPTION
안녕하세요 니야-!
리뷰어로 만나게 되어 반갑습니다🙌
voiceOver 테스트 하면서 필요성을 느낀 부분 위주로 추가해보았습니다.
리뷰 잘 부탁드려요!🙏

## 🔥 결과

<!-- 개선 작업 후 모바일 낭독기를 사용해서 미션 페이지를 읽어보세요 -->

- 배포한 페이지 접근 경로(GitHub Pages): https://thgml05.github.io/a11y-airline/
- 스크린 리더 화면 녹화 영상 (before / after)

### before

https://github.com/user-attachments/assets/c1bea2fb-8f53-4763-bad0-04bb0bc0520e

### after

https://github.com/user-attachments/assets/acdaf582-1f9f-4574-be0f-a5289e0a03cd

## lighthouse

### before
<img width="602" height="639" alt="before" src="https://github.com/user-attachments/assets/3581664f-657e-4209-8baf-13ff670ca26e" />

### after
<img width="597" height="603" alt="after" src="https://github.com/user-attachments/assets/9799cd35-bff1-4d35-b393-d4a8e87ccb73" />

## ✅ 개선 작업 목록

<!-- 각 요구 사항을 위해 어떤 부분을 고민/학습해보았고, 결과적으로 어떤 개선 작업을 진행했는지 적어주세요-->

**1 컴포넌트 접근성 개선 - 이미지 캐로셀**

- [x]  스크린 리더가 캐로셀의 전체 아이템 수를 읽을 수 있어야 합니다.
- [x]  스크린 리더가 이미지 캐로셀 내 각 아이템 정보를 읽을 수 있어야 합니다.
    - [x]  여행지, 좌석 유형, 가격 정보를 한번에 읽을 수 있어야 합니다.
    - [x]  이전/다음 아이템으로 이동하고 현재 보이는 아이템의 정보를 읽을 수 있어야 합니다.
- [x]  각 아이템을 선택하면 각각에 맞는 링크로 이동할 수 있어야 합니다.

**2 페이지 접근성 개선**

- [x]  페이지를 하나의 문서로 읽을 수 있어야 합니다.
    - [x]  페이지에 적절한 제목(title)을 제공하세요. 제목은 페이지의 주요 내용을 간결하게 설명해야 합니다.
    - [x]  페이지의 주요 영역을 시맨틱 태그를 사용해 명확히 구분해 주세요
    - [x]  헤딩을 논리적인 순서로 사용해 페이지 구조를 명확히 해주세요
- [x]  키보드 사용자를 위해 페이지 최상단에 '본문으로 바로가기' 링크를 제공해 반복되는 메뉴를 건너뛸 수 있게 해주세요

**작업 목록**

- 각 캐로셀 버튼 태그에 aria-label을 추가하여 해당 여행 상품에 대한 설명을 작성하였습니다.
    - 추가로, aria-label에 대한 설명 문장을 모두 마침표로 구분하여 voiceOver가 읽어줄 때 쉬는 구간이 생기도록 설정하였습니다.
- 각 캐로셀 버튼 태그에 aria-live를 추가하여 다음 여행 상품으로 넘어갔을 때 자동으로 읽어주도록 설정하였습니다.
- index.html 파일에서 title과 description meta 태그를 추가해주었습니다.
- 필요한 부분에 시맨틱 태그를 적용해주었습니다.
- skipLink 스타일을 작성하여 페이지에서 보이지 않는 "본문으로 바로가기" 버튼을 추가하였습니다.
- 승객 인원을 선택하는 박스에서 도움말 이미지 태그에 aira-label로 추가하여 "최대 3명까지의 인원이 선택 가능하다"는 설명을 읽어주도록 설정하였습니다.
- 다음과 이전 여행상품으로 이동하는 버튼의 너비가 voiceOver로 선택할 때 너무 좁은 것 같아 padding을 조절해주었습니다.

## 🧐 우리 팀의 접근성 체크리스트
### 우리 팀 서비스의 핵심 플로우
*날짜 선택 → 방 이름 입력 → 시간 선택 → 마감기한 선택 → 방 만들기*
### 현재 접근성 문제 분석
### 1. 화면을 볼 수 없는 사용자가 이 단계를 완료할 수 있는가?
#### [데스크탑]
현재 달력 (날짜 선택) → 방 입력 → 투표 마감 기한 순으로 연결되어 있는데, *‘시간 선택‘에 대한 Tab 플로우가 빠져있는 상황*이라 일정 단계를 건너뛸 수밖에 없는 구조이다. 또한, 단계 별 순서가 명확하지 않아 사용자 입장에서 어떤 순서로 진행을 해야 할지 알 수 없다.
#### [모바일]
퍼널로 날짜 선택과, 제목 및 시간 선택이 나누어져있는데 *다음 단계에서 어떤 일이 일어나는지 잘 모르겠다.* 날짜 선택 면에서도 어떤 날짜를 선택할 수 있고, 다음 달로는 어떻게 넘어가는지 등에 대해서 알 수 있는 방법이 없다.
### 2. 이 단계에서 제공하는 정보나 지시 사항이 모든 사용자에게 명확한가?
*명확하지 않다.* 다음 버튼을 눌러도 다음에 어떤 단계가 이루어지는지에 대한 안내가 없어 퍼널로 나누어져있는 단계를 모두 수행하고 넘어가기에는 어려워보인다. 또한, Timepicker의 경우 시간으로 읽는 것이 아니라 ‘공공’ 등으로 읽어서 처음 쓰는 사용자라면 거의 모를 것 같다.
## 우선순위 높은 접근성 체크리스트
1. *각 입력요소에서 사용자가 어떤 것을 입력해야 하는지 바로 알 수 있는가?*
2. *날짜선택과 시간 선택에서 내가 선택할 수 있는게 어떤게 있고, 선택한 결과를 알 수 있는가?*
3. *다음 단계에서 어떤 것을 해야 하는지 알 수 있는가?*