### PR TITLE
[항공사 웹사이트의 컴포넌트 접근성 높이기] 우디(박연기) 미션 제출합니다 

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,15 +1,13 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>A11Y AIRLINE - 항공사 예약 서비스</title>
+  </head>
 
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>React App</title>
-</head>
-
-<body>
-  <div id="root"></div>
-  <script type="module" src="/src/main.tsx"></script>
-</body>
-
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "deploy": "npm run build && npx gh-pages -d dist"
   },
   "author": "woowacourse",
-  "homepage": "https://{username}.github.io/a11y-airline",
+  "homepage": "https://yeongipark.github.io/a11y-airline",
   "license": "MIT",
   "dependencies": {
     "react": "^18.3.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,24 +8,24 @@ function App() {
   return (
     <div className={styles.app}>
       <Navigation />
-      <div className={styles.header}>
+      <header className={styles.header}>
         <h1 className={`${styles.title} heading-1-text`}>A11Y AIRLINE</h1>
         <p className="body-text">
           A11Y AIRLINE은 고객 여러분의 안전하고 쾌적한 여행을 위해 최선을 다하고 있습니다.
         </p>
-      </div>
-      <div id="main-content" className={styles.main}>
-        <div className={styles.flightBooking}>
+      </header>
+      <main id="main-content" className={styles.main}>
+        <section className={styles.flightBooking}>
           <FlightBooking />
-        </div>
-        <div className={styles.travelSection}>
+        </section>
+        <section className={styles.travelSection}>
           <h1 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h1>
           <TravelSection />
-        </div>
-      </div>
-      <div className={styles.footer}>
+        </section>
+      </main>
+      <footer className={styles.footer}>
         <p className="body-text">&copy; A11Y AIRLINE</p>
-      </div>
+      </footer>
       {/* 추가 CHALLENGE: 모달 포커스 트랩 */}
       {/* <PromotionModal /> */}
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,9 @@ import TravelSection from './components/TravelSection';
 function App() {
   return (
     <div className={styles.app}>
+      <a href="#main-content" className={styles.skipLink}>
+        본문으로 바로가기
+      </a>
       <Navigation />
       <header className={styles.header}>
         <h1 className={`${styles.title} heading-1-text`}>A11Y AIRLINE</h1>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,7 @@ function App() {
           <FlightBooking />
         </section>
         <section className={styles.travelSection}>
-          <h1 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h1>
+          <h2 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h2>
           <TravelSection />
         </section>
       </main>

--- a/src/components/TravelSection.module.css
+++ b/src/components/TravelSection.module.css
@@ -86,3 +86,15 @@
   width: 24px;
   height: 24px;
 }
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -64,13 +64,24 @@ const TravelSection = () => {
       <div
         className={styles.carousel}
         role="region"
-        aria-label={`여행 상품 캐로셀, 총 ${travelOptions.length}개 상품`}
+        aria-label={`여행 상품 캐로셀, 총 ${travelOptions.length}개 상품. 현재 ${
+          currentIndex + 1
+        }번째 상품: ${travelOptions[currentIndex].departure} - ${
+          travelOptions[currentIndex].destination
+        } ${travelOptions[
+          currentIndex
+        ].price.toLocaleString()}원. 선택하면 예약 사이트로 넘어갑니다.`}
+        aria-live="polite"
+        aria-atomic="true"
       >
         {travelOptions.map((option, index) => (
           <div
             key={index}
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
             onClick={() => handleCardClick(option.link)}
+            aria-label={`${option.departure}에서 ${option.destination}행, ${
+              option.type
+            }, 가격 ${option.price.toLocaleString()}원 - 예약 페이지로 이동`}
           >
             <img src={option.image} className={styles.cardImage} />
             <div className={styles.cardContent}>

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -79,9 +79,6 @@ const TravelSection = () => {
             key={index}
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
             onClick={() => handleCardClick(option.link)}
-            aria-label={`${option.departure}에서 ${option.destination}행, ${
-              option.type
-            }, 가격 ${option.price.toLocaleString()}원 - 예약 페이지로 이동`}
           >
             <img src={option.image} className={styles.cardImage} />
             <div className={styles.cardContent}>

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -55,24 +55,14 @@ const TravelSection = () => {
     setCurrentIndex((prevIndex) => (prevIndex - 1 + travelOptions.length) % travelOptions.length);
   };
 
-  const handleCardClick = (link: string) => {
-    window.open(link, '_blank', 'noopener,noreferrer');
-  };
-
   return (
     <div className={styles.travelSection}>
       <div
         className={styles.carousel}
         role="region"
-        aria-label={`여행 상품 캐로셀, 총 ${travelOptions.length}개 상품. 현재 ${
+        aria-label={`여행 상품 캐로셀, 총 ${travelOptions.length}개 상품, 현재 ${
           currentIndex + 1
-        }번째 상품: ${travelOptions[currentIndex].departure} - ${
-          travelOptions[currentIndex].destination
-        } ${travelOptions[
-          currentIndex
-        ].price.toLocaleString()}원. 선택하면 예약 사이트로 넘어갑니다.`}
-        aria-live="polite"
-        aria-atomic="true"
+        }번째 상품`}
       >
         {travelOptions.map((option, index) => (
           <a
@@ -81,6 +71,11 @@ const TravelSection = () => {
             href={option.link}
             target="_blank"
             rel="noopener noreferrer"
+            aria-label={`${option.departure}에서 ${option.destination}행 ${
+              option.type
+            }, 가격 ${option.price.toLocaleString()}원. 예약 페이지로 이동`}
+            aria-live="polite"
+            aria-atomic="true"
           >
             <img
               src={option.image}

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -80,7 +80,11 @@ const TravelSection = () => {
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
             onClick={() => handleCardClick(option.link)}
           >
-            <img src={option.image} className={styles.cardImage} />
+            <img
+              src={option.image}
+              className={styles.cardImage}
+              alt={`${option.departure} - ${option.destination}`}
+            />
             <div className={styles.cardContent}>
               <p className={`${styles.cardTitle} heading-3-text`}>
                 {option.departure} - {option.destination}

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -61,9 +61,6 @@ const TravelSection = () => {
 
   return (
     <div className={styles.travelSection}>
-      <button className={`${styles.navButton} ${styles.navButtonPrev}`} onClick={prevTravel}>
-        <img src={chevronLeft} className={styles.navButtonIcon} />
-      </button>
       <div className={styles.carousel}>
         {travelOptions.map((option, index) => (
           <div
@@ -82,8 +79,19 @@ const TravelSection = () => {
           </div>
         ))}
       </div>
-      <button className={`${styles.navButton} ${styles.navButtonNext}`} onClick={nextTravel}>
-        <img src={chevronRight} className={styles.navButtonIcon} />
+      <button
+        className={`${styles.navButton} ${styles.navButtonPrev}`}
+        onClick={prevTravel}
+        aria-label="이전 여행지 보기"
+      >
+        <img src={chevronLeft} className={styles.navButtonIcon} alt="" />
+      </button>
+      <button
+        className={`${styles.navButton} ${styles.navButtonNext}`}
+        onClick={nextTravel}
+        aria-label="다음 여행지 보기"
+      >
+        <img src={chevronRight} className={styles.navButtonIcon} alt="" />
       </button>
     </div>
   );

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -75,10 +75,12 @@ const TravelSection = () => {
         aria-atomic="true"
       >
         {travelOptions.map((option, index) => (
-          <div
+          <a
             key={index}
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
-            onClick={() => handleCardClick(option.link)}
+            href={option.link}
+            target="_blank"
+            rel="noopener noreferrer"
           >
             <img
               src={option.image}
@@ -92,7 +94,7 @@ const TravelSection = () => {
               <p className={`${styles.cardType} body-text`}>{option.type}</p>
               <p className={`${styles.cardPrice} body-text`}>KRW {option.price.toLocaleString()}</p>
             </div>
-          </div>
+          </a>
         ))}
       </div>
       <button

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -61,7 +61,11 @@ const TravelSection = () => {
 
   return (
     <div className={styles.travelSection}>
-      <div className={styles.carousel}>
+      <div
+        className={styles.carousel}
+        role="region"
+        aria-label={`여행 상품 캐로셀, 총 ${travelOptions.length}개 상품`}
+      >
         {travelOptions.map((option, index) => (
           <div
             key={index}


### PR DESCRIPTION
안녕하세요! 하쿠쿠루삥뽕 🫨
잘 지내시는지요!! 
미션에서 만나니까 기분이 묘하네용 ㅎㅎ
잘 부탁드립니다~~~

## 🔥 결과

<!-- 개선 작업 후 모바일 낭독기를 사용해서 미션 페이지를 읽어보세요 -->

- 배포한 페이지 접근 경로(GitHub Pages): https://yeongipark.github.io/a11y-airline/
- 스크린 리더 화면 녹화 영상 (before / after) 
[before]


https://github.com/user-attachments/assets/a93afe4b-78fb-4229-a11d-938f7f67ed3d


[after]

https://github.com/user-attachments/assets/7140769e-9dba-4ad1-842a-0fb7815a5266




## ✅ 개선 작업 목록

노션에 정리했습니다! [노션 보러가기](https://yeoooongi.notion.site/27ccb9aab6148093bc6cc8b821cce2ab?pvs=74)

**1 컴포넌트 접근성 개선 - 이미지 캐로셀**

- [X] 스크린 리더가 캐로셀의 전체 아이템 수를 읽을 수 있어야 합니다.
- [X] 스크린 리더가 이미지 캐로셀 내 각 아이템 정보를 읽을 수 있어야 합니다.
  - [X] 여행지, 좌석 유형, 가격 정보를 한번에 읽을 수 있어야 합니다.
  - [X] 이전/다음 아이템으로 이동하고 현재 보이는 아이템의 정보를 읽을 수 있어야 합니다.
- [X] 각 아이템을 선택하면 각각에 맞는 링크로 이동할 수 있어야 합니다.

**2 페이지 접근성 개선**

- [X] 페이지를 하나의 문서로 읽을 수 있어야 합니다.
  - [X] 페이지에 적절한 제목(title)을 제공하세요. 제목은 페이지의 주요 내용을 간결하게 설명해야 합니다.
  - [X] 페이지의 주요 영역을 시맨틱 태그를 사용해 명확히 구분해 주세요
  - [X] 헤딩을 논리적인 순서로 사용해 페이지 구조를 명확히 해주세요
-  [X] 키보드 사용자를 위해 페이지 최상단에 '본문으로 바로가기' 링크를 제공해 반복되는 메뉴를 건너뛸 수 있게 해주세요

