### PR TITLE
[항공사 웹사이트의 컴포넌트 접근성 높이기] 메리(이수화) 미션 제출합니다

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,15 +1,13 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>A11Y AIRLINE - 항공편 예약 및 여행 상품</title>
+  </head>
 
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>React App</title>
-</head>
-
-<body>
-  <div id="root"></div>
-  <script type="module" src="/src/main.tsx"></script>
-</body>
-
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "deploy": "npm run build && npx gh-pages -d dist"
   },
   "author": "woowacourse",
-  "homepage": "https://{username}.github.io/a11y-airline",
+  "homepage": "https://rosielsh.github.io/a11y-airline",
   "license": "MIT",
   "dependencies": {
     "react": "^18.3.1",

--- a/src/App.module.css
+++ b/src/App.module.css
@@ -9,6 +9,24 @@
   margin: 0 auto;
 }
 
+.skipLink {
+  position: absolute;
+  top: -40px;
+  left: 6px;
+  background: #000;
+  color: #fff;
+  padding: 8px;
+  text-decoration: none;
+  border-radius: 4px;
+  z-index: 1000;
+  font-size: 14px;
+  transition: top 0.3s;
+}
+
+.skipLink:focus {
+  top: 6px;
+}
+
 .header {
   padding: 48px 24px 24px 24px;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,6 @@ function App() {
       </header>
       <main id="main-content" className={styles.main}>
         <section className={styles.flightBooking}>
-          <h2 className="heading-2-text">항공편 예약</h2>
           <FlightBooking />
         </section>
         <section className={styles.travelSection}>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,24 +8,25 @@ function App() {
   return (
     <div className={styles.app}>
       <Navigation />
-      <div className={styles.header}>
+      <header className={styles.header}>
         <h1 className={`${styles.title} heading-1-text`}>A11Y AIRLINE</h1>
         <p className="body-text">
           A11Y AIRLINE은 고객 여러분의 안전하고 쾌적한 여행을 위해 최선을 다하고 있습니다.
         </p>
-      </div>
-      <div id="main-content" className={styles.main}>
-        <div className={styles.flightBooking}>
+      </header>
+      <main id="main-content" className={styles.main}>
+        <section className={styles.flightBooking}>
+          <h2 className="heading-2-text">항공편 예약</h2>
           <FlightBooking />
-        </div>
-        <div className={styles.travelSection}>
-          <h1 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h1>
+        </section>
+        <section className={styles.travelSection}>
+          <h2 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h2>
           <TravelSection />
-        </div>
-      </div>
-      <div className={styles.footer}>
+        </section>
+      </main>
+      <footer className={styles.footer}>
         <p className="body-text">&copy; A11Y AIRLINE</p>
-      </div>
+      </footer>
       {/* 추가 CHALLENGE: 모달 포커스 트랩 */}
       {/* <PromotionModal /> */}
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,9 @@ import TravelSection from './components/TravelSection';
 function App() {
   return (
     <div className={styles.app}>
+      <a href="#main-content" className={styles.skipLink}>
+        본문으로 바로가기
+      </a>
       <Navigation />
       <header className={styles.header}>
         <h1 className={`${styles.title} heading-1-text`}>A11Y AIRLINE</h1>

--- a/src/components/FlightBooking.tsx
+++ b/src/components/FlightBooking.tsx
@@ -36,7 +36,7 @@ const FlightBooking = () => {
 
   return (
     <div className={styles.flightBooking}>
-      <h3 className="heading-3-text">항공권 예매</h3>
+      <h2 className="heading-3-text">항공권 예매</h2>
       <div className={styles.passengerCount}>
         <div className={styles.passengerLabel}>
           <span className="body-text">성인</span>

--- a/src/components/FlightBooking.tsx
+++ b/src/components/FlightBooking.tsx
@@ -36,7 +36,7 @@ const FlightBooking = () => {
 
   return (
     <div className={styles.flightBooking}>
-      <h2 className="heading-2-text">항공권 예매</h2>
+      <h3 className="heading-3-text">항공권 예매</h3>
       <div className={styles.passengerCount}>
         <div className={styles.passengerLabel}>
           <span className="body-text">성인</span>

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -64,7 +64,13 @@ const TravelSection = () => {
       <button className={`${styles.navButton} ${styles.navButtonPrev}`} onClick={prevTravel}>
         <img src={chevronLeft} className={styles.navButtonIcon} />
       </button>
-      <div className={styles.carousel}>
+      <div
+        className={styles.carousel}
+        role="region"
+        aria-label={`여행 상품 캐러셀, 총 ${travelOptions.length}개의 상품 중 ${
+          currentIndex + 1
+        }번째`}
+      >
         {travelOptions.map((option, index) => (
           <div
             key={index}

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -64,11 +64,7 @@ const TravelSection = () => {
       <button
         className={`${styles.navButton} ${styles.navButtonPrev}`}
         onClick={prevTravel}
-        aria-label={`이전 여행 상품으로 이동. 현재 ${currentIndex + 1}번째 상품: ${
-          travelOptions[currentIndex].departure
-        }에서 ${travelOptions[currentIndex].destination}으로 가는 ${
-          travelOptions[currentIndex].type
-        }`}
+        aria-label="이전 여행 상품으로 이동"
       >
         <img src={chevronLeft} className={styles.navButtonIcon} alt="" />
       </button>
@@ -76,9 +72,7 @@ const TravelSection = () => {
       <div
         className={styles.carousel}
         role="region"
-        aria-label={`여행 상품 캐러셀, 총 ${travelOptions.length}개의 상품 중 ${
-          currentIndex + 1
-        }번째`}
+        aria-label={`여행 상품 캐러셀, 총 ${travelOptions.length}개의 상품`}
       >
         {travelOptions.map((option, index) => (
           <div
@@ -95,6 +89,8 @@ const TravelSection = () => {
                 handleCardClick(option.link);
               }
             }}
+            aria-live="polite"
+            aria-atomic="true"
           >
             <img
               src={option.image}
@@ -115,11 +111,7 @@ const TravelSection = () => {
       <button
         className={`${styles.navButton} ${styles.navButtonNext}`}
         onClick={nextTravel}
-        aria-label={`다음 여행 상품으로 이동. 현재 ${currentIndex + 1}번째 상품: ${
-          travelOptions[currentIndex].departure
-        }에서 ${travelOptions[currentIndex].destination}으로 가는 ${
-          travelOptions[currentIndex].type
-        }`}
+        aria-label="다음 여행 상품으로 이동"
       >
         <img src={chevronRight} className={styles.navButtonIcon} alt="" />
       </button>

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -80,6 +80,7 @@ const TravelSection = () => {
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
             onClick={() => handleCardClick(option.link)}
             role="button"
+            tabIndex={index === currentIndex ? 0 : -1}
             aria-label={`${option.departure}에서 ${option.destination}으로 가는 ${
               option.type
             } 여행 상품, 가격 ${option.price.toLocaleString()}원. 클릭하면 예약 페이지로 이동합니다.`}
@@ -89,8 +90,6 @@ const TravelSection = () => {
                 handleCardClick(option.link);
               }
             }}
-            aria-live="polite"
-            aria-atomic="true"
           >
             <img
               src={option.image}

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -76,8 +76,16 @@ const TravelSection = () => {
             key={index}
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
             onClick={() => handleCardClick(option.link)}
+            role="button"
+            aria-label={`${option.departure}에서 ${option.destination}으로 가는 ${
+              option.type
+            } 여행 상품, 가격 ${option.price.toLocaleString()}원`}
           >
-            <img src={option.image} className={styles.cardImage} />
+            <img
+              src={option.image}
+              className={styles.cardImage}
+              alt={`${option.destination} 여행 이미지`}
+            />
             <div className={styles.cardContent}>
               <p className={`${styles.cardTitle} heading-3-text`}>
                 {option.departure} - {option.destination}

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -61,9 +61,18 @@ const TravelSection = () => {
 
   return (
     <div className={styles.travelSection}>
-      <button className={`${styles.navButton} ${styles.navButtonPrev}`} onClick={prevTravel}>
-        <img src={chevronLeft} className={styles.navButtonIcon} />
+      <button
+        className={`${styles.navButton} ${styles.navButtonPrev}`}
+        onClick={prevTravel}
+        aria-label={`이전 여행 상품으로 이동. 현재 ${currentIndex + 1}번째 상품: ${
+          travelOptions[currentIndex].departure
+        }에서 ${travelOptions[currentIndex].destination}으로 가는 ${
+          travelOptions[currentIndex].type
+        }`}
+      >
+        <img src={chevronLeft} className={styles.navButtonIcon} alt="" />
       </button>
+
       <div
         className={styles.carousel}
         role="region"
@@ -96,8 +105,17 @@ const TravelSection = () => {
           </div>
         ))}
       </div>
-      <button className={`${styles.navButton} ${styles.navButtonNext}`} onClick={nextTravel}>
-        <img src={chevronRight} className={styles.navButtonIcon} />
+
+      <button
+        className={`${styles.navButton} ${styles.navButtonNext}`}
+        onClick={nextTravel}
+        aria-label={`다음 여행 상품으로 이동. 현재 ${currentIndex + 1}번째 상품: ${
+          travelOptions[currentIndex].departure
+        }에서 ${travelOptions[currentIndex].destination}으로 가는 ${
+          travelOptions[currentIndex].type
+        }`}
+      >
+        <img src={chevronRight} className={styles.navButtonIcon} alt="" />
       </button>
     </div>
   );

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -88,7 +88,13 @@ const TravelSection = () => {
             role="button"
             aria-label={`${option.departure}에서 ${option.destination}으로 가는 ${
               option.type
-            } 여행 상품, 가격 ${option.price.toLocaleString()}원`}
+            } 여행 상품, 가격 ${option.price.toLocaleString()}원. 클릭하면 예약 페이지로 이동합니다.`}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                handleCardClick(option.link);
+              }
+            }}
           >
             <img
               src={option.image}

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -90,6 +90,8 @@ const TravelSection = () => {
                 handleCardClick(option.link);
               }
             }}
+            aria-live="polite"
+            aria-atomic="true"
           >
             <img
               src={option.image}


### PR DESCRIPTION
안녕하세요 상추!
상추가 없는 선릉캠은 너무 쓸쓸하네요...

이번 미션 잘 부탁드립니다 🥬🥬🥬🥬

---

## 🔥 결과

<!-- 개선 작업 후 모바일 낭독기를 사용해서 미션 페이지를 읽어보세요 -->

- 배포한 페이지 접근 경로(GitHub Pages): https://rosielsh.github.io/a11y-airline/
- 스크린 리더 화면 녹화 영상 (before / after)

### before
https://github.com/user-attachments/assets/7cb987af-bbc4-4a43-8652-2995244eac37

### after
https://github.com/user-attachments/assets/74c92a7f-530d-4e7e-b936-e8531e5f14c9



### 개선 전

<img width="867" height="735" alt="1" src="https://github.com/user-attachments/assets/105a552e-b3a2-4051-a072-2f36c84ac161" />

### 개선 후

<img width="866" height="739" alt="2" src="https://github.com/user-attachments/assets/430a0308-e11c-4530-9f5a-d18e61fab5e0" />


## ✅ 개선 작업 목록

<!-- 각 요구 사항을 위해 어떤 부분을 고민/학습해보았고, 결과적으로 어떤 개선 작업을 진행했는지 적어주세요-->

**1) 컴포넌트 접근성 개선 - 이미지 캐로셀**

- 스크린 리더가 캐로셀의 전체 아이템 수를 읽을 수 있어야 합니다. 
    ⇒ `aria-label`과 `role` 속성을 추가하여 스크린 리더가 전체 아이템 수를 인식할 수 있도록 함
    
    - `role=”region”` : 케러셀을 페이지의 특정 영역으로 식별
    - `aria-label - 스크린 리더가 전체 아이템 수와 현재 위치를 읽을 수 있도록 함
- 스크린 리더가 이미지 캐로셀 내 각 아이템 정보를 읽을 수 있어야 합니다.
    - 여행지, 좌석 유형, 가격 정보를 한번에 읽을 수 있어야 합니다.
        - `role=”button”` : 각 카드가 클릭 가능한 버튼임을 명시
        - `aria-label` 추가
    - 이전/다음 아이템으로 이동하고 현재 보이는 아이템의 정보를 읽을 수 있어야 합니다.
        - `aria-label` 추가
- 각 아이템을 선택하면 각각에 맞는 링크로 이동할 수 있어야 합니다.

**2) 페이지 접근성 개선**

- 페이지를 하나의 문서로 읽을 수 있어야 합니다.
    - 페이지에 적절한 제목(title)을 제공하세요. 제목은 페이지의 주요 내용을 간결하게 설명해야 합니다.
        - `title` 수정 - `A11Y AIRLINE - 항공편 예약 및 여행 상품`
    - 페이지의 주요 영역을 시맨틱 태그를 사용해 명확히 구분해 주세요
        - `App.tsx`에서 시맨틱 태그를 개선
            - `header`: 페이지 헤더 영역
            - `main`: 메인 콘텐츠
            - `section`: 항공권 예약 섹션, 여행 상품 섹션으로 구분
            - `footer`: 푸터 영역
    - 헤딩을 논리적인 순서로 사용해 페이지 구조를 명확히 해주세요
        - `FlightBooking` 컴포넌트에서 중복된 H2 헤딩을 H3로 변경
        
        ```jsx
        H1: "A11Y AIRLINE" (페이지 제목)
        ├── H2: "항공편 예약" (섹션 제목)
        │   └── H3: "항공권 예매" (하위 제목)
        └── H2: "지금 떠나기 좋은 여행" (섹션 제목)
        ```
        
- 키보드 사용자를 위해 페이지 최상단에 '본문으로 바로가기' 링크를 제공해 반복되는 메뉴를 건너뛸 수 있게 해주세요 (a.k.a. skip link / skip navigation. cf. [[github.com](https://github.com/)](https://github.com/))
    - 본문으로 바로가기 태그 및 스타일 추가
    
    ```jsx
     <a href="#main-content" className={styles.skipLink}>
            본문으로 바로가기
          </a>
    ```

<!-- 🧐 우리 팀의 접근성 체크리스트

우리 서비스에서 이런 부분의 접근성은 챙겨봐야겠다! 하는 체크리스트 v1을 만들고, 리뷰어와 의견을 나눠보세요
- 우리 팀 서비스에서 가장 중요하고 자주 사용되는 기능 플로우 1개를 선택하고 간단히 나열해 주세요 (예: 로그인 → 상품 검색 → 상품 선택 → 장바구니 추가 → 결제)
- 해당 플로우의 각 단계에 대해 다음 질문을 생각해 보세요.
  - 1. 화면을 볼 수 없는 사용자가 이 단계를 완료할 수 있는가?
  - 2. 이 단계에서 제공하는 정보나 지시 사항이 모든 사용자에게 명확한가?
- 질문에 대해 팀원들과 의견을 나눠본 것을 바탕으로, 우리 팀만의 접근성 체크리스트 v1을 만들고 리뷰어와 의견을 나눠보세요. (예: "모든 이미지에 적절한 대체 텍스트가 제공되는가?")
-->

##  🧐 커피빵 서비스 접근성 체크리스트 v1

<!-- 우리 서비스에서 이런 부분의 접근성은 챙겨봐야겠다! 하는 체크리스트 v1을 만들고, 리뷰어와 의견을 나눠보세요
- 우리 팀 서비스에서 가장 중요하고 자주 사용되는 기능 플로우 1개를 선택하고 간단히 나열해 주세요 (예: 로그인 → 상품 검색 → 상품 선택 → 장바구니 추가 → 결제)
- 해당 플로우의 각 단계에 대해 다음 질문을 생각해 보세요.
  - 1. 화면을 볼 수 없는 사용자가 이 단계를 완료할 수 있는가?
  - 2. 이 단계에서 제공하는 정보나 지시 사항이 모든 사용자에게 명확한가?
- 질문에 대해 팀원들과 의견을 나눠본 것을 바탕으로, 우리 팀만의 접근성 체크리스트 v1을 만들고 리뷰어와 의견을 나눠보세요. (예: "모든 이미지에 적절한 대체 텍스트가 제공되는가?")
-->

### 📋 주요 기능 플로우
**커피빵 게임 참여 플로우**: 홈 → 방 생성/참가 → 닉네임 입력 → 메뉴 선택 → 로비 → 미니게임 플레이 → 룰렛 → 당첨 결과 확인

### 🔍 접근성 체크리스트

#### **1단계: 홈 화면**
- [ ] **화면을 볼 수 없는 사용자가 방 만들기/참가하기를 구분할 수 있는가?**
- [ ] **초기 방문자를 위한 스플래시 화면이 스크린 리더 사용자에게 적절한가?**
#### **2단계: 닉네임 입력**
- [ ] **닉네임 중복 검사 결과를 스크린 리더가 알 수 있는가?**
- [ ] **입력 오류 시 명확한 오류 메시지가 제공되는가?**
#### **3단계: 메뉴 선택**
- [ ] **메뉴 이미지만으로 선택할 수 있는가?**
#### **4단계: 로비 (게임 준비)**
- [ ] **참가자, 룰렛, 미니게임 탭 간 전환이 가능한가?**
- [ ] **각 참가자의 준비 상태를 스크린 리더가 알 수 있는가?**
- [ ] **호스트/게스트 역할에 따른 버튼 차이가 명확한가?**
#### **5단계: 미니게임 플레이**
- [ ] **카드 선택 게임에서 카드가 스크린 리더로 구분 가능한가?**
- [ ] **게임 진행 상황과 타이머 정보가 접근 가능한가?**
- [ ] **게임 결과를 텍스트로 확인할 수 있는가?**
#### **6단계: 룰렛**
- [ ] **룰렛 회전 상태를 스크린 리더가 알 수 있는가?**
- [ ] **각 참가자의 확률 정보가 접근 가능한가?**
- [ ] **당첨자 발표를 스크린 리더가 인식할 수 있는가?**
#### **7단계: 당첨 결과 확인**
- [ ] **당첨자 결과와 주문 리스트가 스크린 리더로 읽을 수 있는가?**
- [ ] **게임 종료 후 다음 액션(새 게임, 방 나가기 등)이 명확한가?**