### PR TITLE
[항공사 웹사이트의 컴포넌트 접근성 높이기] 하쿠(이동현) 미션 제출합니다 

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,15 +1,13 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>A11Y AIRLINE - 안전하고 쾌적한 여행을 위한 항공사</title>
+  </head>
 
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>React App</title>
-</head>
-
-<body>
-  <div id="root"></div>
-  <script type="module" src="/src/main.tsx"></script>
-</body>
-
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "deploy": "npm run build && npx gh-pages -d dist"
   },
   "author": "woowacourse",
-  "homepage": "https://{username}.github.io/a11y-airline",
+  "homepage": "https://ha-kuku.github.io/a11y-airline",
   "license": "MIT",
   "dependencies": {
     "react": "^18.3.1",

--- a/src/Accessibility.css
+++ b/src/Accessibility.css
@@ -9,3 +9,16 @@
   white-space: nowrap;
   border: 0;
 }
+
+.skipLink {
+  position: absolute;
+  left: 0;
+  top: -40px;
+  background: #000;
+  color: #fff;
+  padding: 8px 12px;
+  z-index: 1000;
+}
+.skipLink:focus {
+  top: 0;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import styles from './App.module.css';
 import Navigation from './components/Navigation';
 import FlightBooking from './components/FlightBooking';
 import TravelSection from './components/TravelSection';
-// import PromotionModal from './components/PromotionModal';
+import PromotionModal from './components/PromotionModal';
 
 function App() {
   return (
@@ -32,8 +32,7 @@ function App() {
       <footer className={styles.footer}>
         <p className="body-text">&copy; A11Y AIRLINE</p>
       </footer>
-      {/* 추가 CHALLENGE: 모달 포커스 트랩 */}
-      {/* <PromotionModal /> */}
+      <PromotionModal />
     </div>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,25 +7,31 @@ import TravelSection from './components/TravelSection';
 function App() {
   return (
     <div className={styles.app}>
-      <Navigation />
-      <div className={styles.header}>
-        <h1 className={`${styles.title} heading-1-text`}>A11Y AIRLINE</h1>
-        <p className="body-text">
-          A11Y AIRLINE은 고객 여러분의 안전하고 쾌적한 여행을 위해 최선을 다하고 있습니다.
-        </p>
-      </div>
-      <div id="main-content" className={styles.main}>
-        <div className={styles.flightBooking}>
-          <FlightBooking />
+      <a href="#main-content" className="visually-hidden">
+        본문으로 바로가기
+      </a>
+
+      <header className={styles.header}>
+        <Navigation />
+        <div className={styles.headerContent}>
+          <h1 className={`${styles.title} heading-1-text`}>A11Y AIRLINE</h1>
+          <p className="body-text">
+            A11Y AIRLINE은 고객 여러분의 안전하고 쾌적한 여행을 위해 최선을 다하고 있습니다.
+          </p>
         </div>
-        <div className={styles.travelSection}>
+      </header>
+      <main id="main-content" className={styles.main}>
+        <section className={styles.flightBooking}>
+          <FlightBooking />
+        </section>
+        <section className={styles.travelSection}>
           <h1 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h1>
           <TravelSection />
-        </div>
-      </div>
-      <div className={styles.footer}>
+        </section>
+      </main>
+      <footer className={styles.footer}>
         <p className="body-text">&copy; A11Y AIRLINE</p>
-      </div>
+      </footer>
       {/* 추가 CHALLENGE: 모달 포커스 트랩 */}
       {/* <PromotionModal /> */}
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,7 @@ import PromotionModal from './components/PromotionModal';
 function App() {
   return (
     <div className={styles.app}>
-      <a href="#main-content" className="visually-hidden">
+      <a href="#main-content" className="skipLink">
         본문으로 바로가기
       </a>
 

--- a/src/components/PromotionModal.tsx
+++ b/src/components/PromotionModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import close from '../assets/close.svg';
 
@@ -6,19 +6,73 @@ import styles from './PromotionModal.module.css';
 
 const PromotionModal = () => {
   const [isOpen, setIsOpen] = useState(true);
+  const modalRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
 
   const closeModal = () => {
     setIsOpen(false);
   };
+
+  const getFocusableElements = () => {
+    if (!modalRef.current) return [];
+
+    return Array.from(modalRef.current.querySelectorAll('button:not([disabled]')) as HTMLElement[];
+  };
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      closeModal();
+      return;
+    }
+
+    if (e.key === 'Tab') {
+      const focusableElements = getFocusableElements();
+      if (focusableElements.length === 0) return;
+
+      const firstElement = focusableElements[0];
+      const lastElement = focusableElements[focusableElements.length - 1];
+      if (e.shiftKey) {
+        if (document.activeElement === firstElement) {
+          e.preventDefault();
+          lastElement.focus();
+        }
+      } else {
+        if (document.activeElement === lastElement) {
+          e.preventDefault();
+          firstElement.focus();
+        }
+      }
+    }
+  };
+
+  useEffect(() => {
+    if (isOpen) {
+      const timer = setTimeout(() => {
+        if (closeButtonRef.current) {
+          closeButtonRef.current.focus();
+        }
+      }, 0);
+
+      document.addEventListener('keydown', handleKeyDown);
+
+      document.body.style.overflow = 'hidden';
+
+      return () => {
+        clearTimeout(timer);
+        document.removeEventListener('keydown', handleKeyDown);
+        document.body.style.overflow = '';
+      };
+    }
+  });
 
   if (!isOpen) {
     return null;
   }
 
   return (
-    <div className={styles.modal}>
+    <div className={styles.modal} role="dialog">
       <div className={styles.modalBackdrop} onClick={closeModal}></div>
-      <div className={styles.modalContainer}>
+      <div className={styles.modalContainer} ref={modalRef}>
         <div className={styles.modalContent}>
           <h2 className={`${styles.modalTitle} heading-2-text`}>여행할 땐 A11Y AIRLINE 앱</h2>
           <p className={`${styles.modalDescription} body-text`}>
@@ -26,8 +80,13 @@ const PromotionModal = () => {
             <br />- 앱으로 더욱 편하게 여행하세요!
           </p>
           <button className={`${styles.modalActionButton} button-text`}>앱에서 열기</button>
-          <button className={`${styles.modalCloseButton} heading-2-text`} onClick={closeModal}>
-            <img src={close} />
+          <button
+            ref={closeButtonRef}
+            className={`${styles.modalCloseButton} heading-2-text`}
+            onClick={closeModal}
+            aria-label="프로모션 팝업 닫기"
+          >
+            <img src={close} alt="" />
           </button>
         </div>
       </div>

--- a/src/components/PromotionModal.tsx
+++ b/src/components/PromotionModal.tsx
@@ -70,11 +70,13 @@ const PromotionModal = () => {
   }
 
   return (
-    <div className={styles.modal} role="dialog">
+    <div className={styles.modal} role="dialog" aria-modal="true" aria-labelledby="modal-title">
       <div className={styles.modalBackdrop} onClick={closeModal}></div>
       <div className={styles.modalContainer} ref={modalRef}>
         <div className={styles.modalContent}>
-          <h2 className={`${styles.modalTitle} heading-2-text`}>여행할 땐 A11Y AIRLINE 앱</h2>
+          <h2 id="modal-title" className={`${styles.modalTitle} heading-2-text`}>
+            여행할 땐 A11Y AIRLINE 앱
+          </h2>
           <p className={`${styles.modalDescription} body-text`}>
             체크인, 탑승권 저장, 수하물 알림까지
             <br />- 앱으로 더욱 편하게 여행하세요!

--- a/src/components/PromotionModal.tsx
+++ b/src/components/PromotionModal.tsx
@@ -8,6 +8,7 @@ const PromotionModal = () => {
   const [isOpen, setIsOpen] = useState(true);
   const modalRef = useRef<HTMLDivElement>(null);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const focusableElementsRef = useRef<HTMLElement[]>([]);
 
   const closeModal = () => {
     setIsOpen(false);
@@ -16,7 +17,7 @@ const PromotionModal = () => {
   const getFocusableElements = () => {
     if (!modalRef.current) return [];
 
-    return Array.from(modalRef.current.querySelectorAll('button:not([disabled]')) as HTMLElement[];
+    return Array.from(modalRef.current.querySelectorAll('button:not([disabled])')) as HTMLElement[];
   };
 
   const handleKeyDown = (e: KeyboardEvent) => {
@@ -26,7 +27,7 @@ const PromotionModal = () => {
     }
 
     if (e.key === 'Tab') {
-      const focusableElements = getFocusableElements();
+      const focusableElements = focusableElementsRef.current;
       if (focusableElements.length === 0) return;
 
       const firstElement = focusableElements[0];
@@ -47,6 +48,8 @@ const PromotionModal = () => {
 
   useEffect(() => {
     if (isOpen) {
+      focusableElementsRef.current = getFocusableElements();
+
       const timer = setTimeout(() => {
         if (closeButtonRef.current) {
           closeButtonRef.current.focus();

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -81,6 +81,10 @@ const TravelSection = () => {
               }
             }}
             tabIndex={index === currentIndex ? 0 : -1}
+            role="button"
+            aria-label={`${option.departure}에서 ${option.destination}로 가는 ${
+              option.type
+            } 항공편, 가격 ${option.price.toLocaleString()}원`}
           >
             <img
               src={option.image}

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -60,9 +60,13 @@ const TravelSection = () => {
   };
 
   return (
-    <div className={styles.travelSection}>
-      <button className={`${styles.navButton} ${styles.navButtonPrev}`} onClick={prevTravel}>
-        <img src={chevronLeft} className={styles.navButtonIcon} />
+    <section className={styles.travelSection}>
+      <button
+        className={`${styles.navButton} ${styles.navButtonPrev}`}
+        onClick={prevTravel}
+        aria-label="이전 여행 상품"
+      >
+        <img src={chevronLeft} className={styles.navButtonIcon} alt="" />
       </button>
       <div className={styles.carousel}>
         {travelOptions.map((option, index) => (
@@ -70,8 +74,19 @@ const TravelSection = () => {
             key={index}
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
             onClick={() => handleCardClick(option.link)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                handleCardClick(option.link);
+              }
+            }}
+            tabIndex={index === currentIndex ? 0 : -1}
           >
-            <img src={option.image} className={styles.cardImage} />
+            <img
+              src={option.image}
+              className={styles.cardImage}
+              alt={`${option.destination} 여행지`}
+            />
             <div className={styles.cardContent}>
               <p className={`${styles.cardTitle} heading-3-text`}>
                 {option.departure} - {option.destination}
@@ -82,10 +97,20 @@ const TravelSection = () => {
           </div>
         ))}
       </div>
-      <button className={`${styles.navButton} ${styles.navButtonNext}`} onClick={nextTravel}>
-        <img src={chevronRight} className={styles.navButtonIcon} />
+      <button
+        className={`${styles.navButton} ${styles.navButtonNext}`}
+        onClick={nextTravel}
+        aria-label="다음 여행 상품"
+      >
+        <img src={chevronRight} className={styles.navButtonIcon} alt="" />
       </button>
-    </div>
+
+      <div className="visually-hidden" aria-live="polite">
+        {travelOptions.length}개 중 {currentIndex + 1}번째 상품:{' '}
+        {travelOptions[currentIndex].departure} {travelOptions[currentIndex].destination}{' '}
+        {travelOptions[currentIndex].type}
+      </div>
+    </section>
   );
 };
 


### PR DESCRIPTION
안녕하세요! 피터:)
이번 미션 리뷰어로 만나뵙게 되어 반갑습니다.
미션을 진행하면서 aria 속성을 필요한 곳에만 쓰는 방향으로 생각하여 진행하였습니다.
코드랑 PR 읽어보시고 더 필요한 부분 있으면 말씀해주세요!
리뷰 잘 부탁드립니다🥹

## 🔥 결과

<!-- 개선 작업 후 모바일 낭독기를 사용해서 미션 페이지를 읽어보세요 -->

- 배포한 페이지 접근 경로(GitHub Pages): [배포링크](https://ha-kuku.github.io/a11y-airline/)

- 스크린 리더 화면 녹화 영상 (before / after)

**before**

https://github.com/user-attachments/assets/490644b1-ec82-45de-9c2f-2b9969f1a024


**after**

https://github.com/user-attachments/assets/e3f2db19-dfe0-4461-802c-c55f8faad399

- lighthouse 접근성 점수

**<개선 전>**
<img width="1910" height="912" alt="image" src="https://github.com/user-attachments/assets/1d6d0410-2484-4b32-813e-fc3d98402ec4" />

**<개선 후>**
<img width="567" height="386" alt="image" src="https://github.com/user-attachments/assets/b64f512b-03d5-4d56-993f-3229ed0b908b" />


## ✅ 개선 작업 목록

<!-- 각 요구 사항을 위해 어떤 부분을 고민/학습해보았고, 결과적으로 어떤 개선 작업을 진행했는지 적어주세요-->

**1 컴포넌트 접근성 개선 - 이미지 캐로셀**

- [x] 스크린 리더가 캐로셀의 전체 아이템 수를 읽을 수 있어야 합니다.
- [x] 스크린 리더가 이미지 캐로셀 내 각 아이템 정보를 읽을 수 있어야 합니다.
  - [x] 여행지, 좌석 유형, 가격 정보를 한번에 읽을 수 있어야 합니다.
  - [x] 이전/다음 아이템으로 이동하고 현재 보이는 아이템의 정보를 읽을 수 있어야 합니다.
- [x] 각 아이템을 선택하면 각각에 맞는 링크로 이동할 수 있어야 합니다.

**2 페이지 접근성 개선**

- [x] 페이지를 하나의 문서로 읽을 수 있어야 합니다.
  - [x] 페이지에 적절한 제목(title)을 제공하세요. 제목은 페이지의 주요 내용을 간결하게 설명해야 합니다.
  - [x] 페이지의 주요 영역을 시맨틱 태그를 사용해 명확히 구분해 주세요
  - [x] 헤딩을 논리적인 순서로 사용해 페이지 구조를 명확히 해주세요
- [x] 키보드 사용자를 위해 페이지 최상단에 '본문으로 바로가기' 링크를 제공해 반복되는 메뉴를 건너뛸 수 있게 해주세요

**주요 개선 사항**
- `section`과 `aria-label`: 캐러셀 전체 영역을 의미적으로 정의
- `aria-live="polite"`: 캐러셀 변경 시 스크린 리더에 알림
- `aria-label`로 전체 아이템 수 정보 제공 및 버튼 역할 제공
- 이미지에 `alt` 속성: 의미있는 이미지는 설명, 장식용은 ''으로 스킵
- 키보드 접근성: 키보드로도 조작 가능
- Skip link: 페이지 최상단에 "본문으로 바로가기" 링크 추가
- role="dialog", aria-modal="true": 스크린 리더가 팝업임을 인지
- aria-labelledby : 팝업의 제목과 설명을 연결
- 포커스 트랩: Tab 키로 팝업 내에서만 포커스 순환
- 초기 포커스: 모달 열릴 때 자동으로 닫기 버튼에 포커스
- body 스크롤 방지: 모달 열려있는 동안 배경 스크롤 차단