### PR TITLE
[항공사 웹사이트의 컴포넌트 접근성 높이기] 수이(김수연) 미션 제출합니다

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,15 +1,13 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>A11Y AIRLINE</title>
+  </head>
 
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>React App</title>
-</head>
-
-<body>
-  <div id="root"></div>
-  <script type="module" src="/src/main.tsx"></script>
-</body>
-
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "deploy": "npm run build && npx gh-pages -d dist"
   },
   "author": "woowacourse",
-  "homepage": "https://{username}.github.io/a11y-airline",
+  "homepage": "https://shuyeon.github.io/a11y-airline",
   "license": "MIT",
   "dependencies": {
     "react": "^18.3.1",

--- a/src/App.module.css
+++ b/src/App.module.css
@@ -40,3 +40,25 @@
   background-color: white;
   text-align: center;
 }
+
+.skipLink {
+  position: absolute;
+  left: -9999px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+
+.skipLink:focus {
+  left: 0;
+  top: 0;
+  width: auto;
+  height: auto;
+  padding: 8px 16px;
+  background: #005fcc;
+  color: #fff;
+  font-weight: bold;
+  border-radius: 4px;
+  z-index: 1000;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,24 +8,26 @@ function App() {
   return (
     <div className={styles.app}>
       <Navigation />
-      <div className={styles.header}>
+      <header className={styles.header}>
         <h1 className={`${styles.title} heading-1-text`}>A11Y AIRLINE</h1>
         <p className="body-text">
           A11Y AIRLINE은 고객 여러분의 안전하고 쾌적한 여행을 위해 최선을 다하고 있습니다.
         </p>
-      </div>
-      <div id="main-content" className={styles.main}>
+      </header>
+
+      <main id="main-content" className={styles.main}>
         <div className={styles.flightBooking}>
           <FlightBooking />
         </div>
-        <div className={styles.travelSection}>
-          <h1 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h1>
+        <section className={styles.travelSection}>
+          <h2 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h2>
           <TravelSection />
-        </div>
-      </div>
-      <div className={styles.footer}>
+        </section>
+      </main>
+
+      <footer className={styles.footer}>
         <p className="body-text">&copy; A11Y AIRLINE</p>
-      </div>
+      </footer>
       {/* 추가 CHALLENGE: 모달 포커스 트랩 */}
       {/* <PromotionModal /> */}
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,9 +19,9 @@ function App() {
       </header>
 
       <main id="main-content" className={styles.main}>
-        <div className={styles.flightBooking}>
+        <section className={styles.flightBooking}>
           <FlightBooking />
-        </div>
+        </section>
         <section className={styles.travelSection}>
           <h2 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h2>
           <TravelSection />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,9 @@ import TravelSection from './components/TravelSection';
 function App() {
   return (
     <div className={styles.app}>
+      <a href="#main-content" className={styles.skipLink}>
+        본문으로 바로가기
+      </a>
       <Navigation />
       <header className={styles.header}>
         <h1 className={`${styles.title} heading-1-text`}>A11Y AIRLINE</h1>

--- a/src/components/FlightBooking.tsx
+++ b/src/components/FlightBooking.tsx
@@ -35,9 +35,9 @@ const FlightBooking = () => {
   }, [adultCount]);
 
   return (
-    <div className={styles.flightBooking}>
+    <form className={styles.flightBooking}>
       <h2 className="heading-2-text">항공권 예매</h2>
-      <div className={styles.passengerCount}>
+      <fieldset className={styles.passengerCount}>
         <div className={styles.passengerLabel}>
           <span className="body-text">성인</span>
           <div
@@ -50,22 +50,32 @@ const FlightBooking = () => {
           </div>
         </div>
         <div className={styles.counter}>
-          <button className="button-text" onClick={decrementCount} aria-label="성인 승객 감소">
+          <button
+            className="button-text"
+            onClick={decrementCount}
+            aria-label="성인 승객 감소"
+            type="button"
+          >
             <img src={minus} alt="" />
           </button>
           <span aria-live="polite">{adultCount}</span>
-          <button className="button-text" onClick={incrementCount} aria-label="성인 승객 증가">
+          <button
+            className="button-text"
+            onClick={incrementCount}
+            aria-label="성인 승객 증가"
+            type="button"
+          >
             <img src={plus} alt="" />
           </button>
         </div>
-      </div>
+      </fieldset>
       {statusMessage && (
         <div className="visually-hidden" role="alert">
           {statusMessage}
         </div>
       )}
       <button className={styles.searchButton}>항공편 검색</button>
-    </div>
+    </form>
   );
 };
 

--- a/src/components/FlightBooking.tsx
+++ b/src/components/FlightBooking.tsx
@@ -38,6 +38,7 @@ const FlightBooking = () => {
     <form className={styles.flightBooking}>
       <h2 className="heading-2-text">항공권 예매</h2>
       <fieldset className={styles.passengerCount}>
+        <legend className="visually-hidden">승객 수 선택</legend>
         <div className={styles.passengerLabel}>
           <span className="body-text">성인</span>
           <div

--- a/src/components/TravelSection.module.css
+++ b/src/components/TravelSection.module.css
@@ -17,6 +17,7 @@
   display: none;
   width: 100%;
   height: 246px;
+  color: inherit;
 }
 
 .cardActive {

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -93,14 +93,14 @@ const TravelSection = () => {
         onClick={prevTravel}
         aria-label="이전 여행 상품"
       >
-        <img src={chevronLeft} className={styles.navButtonIcon} />
+        <img src={chevronLeft} className={styles.navButtonIcon} alt="" />
       </button>
       <button
         className={`${styles.navButton} ${styles.navButtonNext}`}
         onClick={nextTravel}
         aria-label="다음 여행 상품"
       >
-        <img src={chevronRight} className={styles.navButtonIcon} />
+        <img src={chevronRight} className={styles.navButtonIcon} alt="" />
       </button>
     </div>
   );

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -56,7 +56,10 @@ const TravelSection = () => {
   };
 
   return (
-    <div className={styles.travelSection}>
+    <div className={styles.travelSection} aria-live="polite">
+      <p className="visually-hidden">{`${travelOptions.length}개의 여행 상품 중 ${
+        currentIndex + 1
+      }번째 상품.`}</p>
       <ul className={styles.carousel}>
         {travelOptions.map((option, index) => (
           <li key={index}>
@@ -65,28 +68,21 @@ const TravelSection = () => {
               target="_blank"
               rel="noopener noreferrer"
               className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
+              aria-label={`${option.departure} 출발 ${option.destination} 도착. ${
+                option.type
+              }. 가격 ${option.price.toLocaleString()} 원.`}
             >
-              <img src={option.image} className={styles.cardImage} />
-              <div className={styles.cardContent} aria-live="polite">
-                <p className="visually-hidden">{`${travelOptions.length}개의 여행 상품 중 ${
-                  currentIndex + 1
-                }번째 상품`}</p>
-                <h3
-                  className={`${styles.cardTitle} heading-3-text`}
-                  aria-label={`${option.departure} 출발. ${option.destination} 도착.`}
-                  role="link"
-                >
+              <img src={option.image} className={styles.cardImage} alt="" />
+              <div className={styles.cardContent}>
+                <h3 className={`${styles.cardTitle} heading-3-text`} aria-hidden="true">
                   {option.departure} - {option.destination}
                 </h3>
-                <p className={`${styles.cardType} body-text`}>{option.type}</p>
-                <p
-                  className={`${styles.cardPrice} body-text`}
-                  aria-label={`가격 ${option.price.toLocaleString()}원.`}
-                  role="link"
-                >
+                <p className={`${styles.cardType} body-text`} aria-hidden="true">
+                  {option.type}
+                </p>
+                <p className={`${styles.cardPrice} body-text`} aria-hidden="true">
                   KRW {option.price.toLocaleString()}
                 </p>
-                <p className="visually-hidden">선택하면 예약 페이지로 이동합니다.</p>
               </div>
             </a>
           </li>

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -56,7 +56,7 @@ const TravelSection = () => {
   };
 
   return (
-    <section className={styles.travelSection}>
+    <div className={styles.travelSection}>
       <button
         className={`${styles.navButton} ${styles.navButtonPrev}`}
         onClick={prevTravel}
@@ -103,7 +103,7 @@ const TravelSection = () => {
       >
         <img src={chevronRight} className={styles.navButtonIcon} />
       </button>
-    </section>
+    </div>
   );
 };
 

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -57,13 +57,6 @@ const TravelSection = () => {
 
   return (
     <div className={styles.travelSection}>
-      <button
-        className={`${styles.navButton} ${styles.navButtonPrev}`}
-        onClick={prevTravel}
-        aria-label="이전 여행 상품"
-      >
-        <img src={chevronLeft} className={styles.navButtonIcon} />
-      </button>
       <article className={styles.carousel}>
         {travelOptions.map((option, index) => (
           <a
@@ -75,11 +68,12 @@ const TravelSection = () => {
           >
             <img src={option.image} className={styles.cardImage} />
             <div className={styles.cardContent} aria-live="polite">
+              <p className="visually-hidden">{`${travelOptions.length}개의 여행 상품 중 ${
+                currentIndex + 1
+              }번째 상품`}</p>
               <h3
                 className={`${styles.cardTitle} heading-3-text`}
-                aria-label={`${travelOptions.length}개의 여행 상품 중 ${
-                  currentIndex + 1
-                }번째 상품. ${option.departure} 출발. ${option.destination} 도착.`}
+                aria-label={`${option.departure} 출발. ${option.destination} 도착.`}
                 role="link"
               >
                 {option.departure} - {option.destination}
@@ -87,15 +81,23 @@ const TravelSection = () => {
               <p className={`${styles.cardType} body-text`}>{option.type}</p>
               <p
                 className={`${styles.cardPrice} body-text`}
-                aria-label={`가격 ${option.price.toLocaleString()}원. 선택하면 예약 페이지로 이동합니다.`}
+                aria-label={`가격 ${option.price.toLocaleString()}원.`}
                 role="link"
               >
                 KRW {option.price.toLocaleString()}
               </p>
+              <p className="visually-hidden">선택하면 예약 페이지로 이동합니다.</p>
             </div>
           </a>
         ))}
       </article>
+      <button
+        className={`${styles.navButton} ${styles.navButtonPrev}`}
+        onClick={prevTravel}
+        aria-label="이전 여행 상품"
+      >
+        <img src={chevronLeft} className={styles.navButtonIcon} />
+      </button>
       <button
         className={`${styles.navButton} ${styles.navButtonNext}`}
         onClick={nextTravel}

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -57,9 +57,6 @@ const TravelSection = () => {
 
   return (
     <div className={styles.travelSection} aria-live="polite">
-      <p className="visually-hidden">{`${travelOptions.length}개의 여행 상품 중 ${
-        currentIndex + 1
-      }번째 상품.`}</p>
       <ul className={styles.carousel}>
         {travelOptions.map((option, index) => (
           <li key={index}>
@@ -68,7 +65,9 @@ const TravelSection = () => {
               target="_blank"
               rel="noopener noreferrer"
               className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
-              aria-label={`${option.departure} 출발 ${option.destination} 도착. ${
+              aria-label={`${travelOptions.length}개의 여행 상품 중 ${currentIndex + 1}번째 상품.${
+                option.departure
+              } 출발 ${option.destination} 도착. ${
                 option.type
               }. 가격 ${option.price.toLocaleString()} 원.`}
             >

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -57,40 +57,41 @@ const TravelSection = () => {
 
   return (
     <div className={styles.travelSection}>
-      <article className={styles.carousel}>
+      <ul className={styles.carousel}>
         {travelOptions.map((option, index) => (
-          <a
-            key={index}
-            className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
-            href={option.link}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <img src={option.image} className={styles.cardImage} />
-            <div className={styles.cardContent} aria-live="polite">
-              <p className="visually-hidden">{`${travelOptions.length}개의 여행 상품 중 ${
-                currentIndex + 1
-              }번째 상품`}</p>
-              <h3
-                className={`${styles.cardTitle} heading-3-text`}
-                aria-label={`${option.departure} 출발. ${option.destination} 도착.`}
-                role="link"
-              >
-                {option.departure} - {option.destination}
-              </h3>
-              <p className={`${styles.cardType} body-text`}>{option.type}</p>
-              <p
-                className={`${styles.cardPrice} body-text`}
-                aria-label={`가격 ${option.price.toLocaleString()}원.`}
-                role="link"
-              >
-                KRW {option.price.toLocaleString()}
-              </p>
-              <p className="visually-hidden">선택하면 예약 페이지로 이동합니다.</p>
-            </div>
-          </a>
+          <li key={index}>
+            <a
+              href={option.link}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
+            >
+              <img src={option.image} className={styles.cardImage} />
+              <div className={styles.cardContent} aria-live="polite">
+                <p className="visually-hidden">{`${travelOptions.length}개의 여행 상품 중 ${
+                  currentIndex + 1
+                }번째 상품`}</p>
+                <h3
+                  className={`${styles.cardTitle} heading-3-text`}
+                  aria-label={`${option.departure} 출발. ${option.destination} 도착.`}
+                  role="link"
+                >
+                  {option.departure} - {option.destination}
+                </h3>
+                <p className={`${styles.cardType} body-text`}>{option.type}</p>
+                <p
+                  className={`${styles.cardPrice} body-text`}
+                  aria-label={`가격 ${option.price.toLocaleString()}원.`}
+                  role="link"
+                >
+                  KRW {option.price.toLocaleString()}
+                </p>
+                <p className="visually-hidden">선택하면 예약 페이지로 이동합니다.</p>
+              </div>
+            </a>
+          </li>
         ))}
-      </article>
+      </ul>
       <button
         className={`${styles.navButton} ${styles.navButtonPrev}`}
         onClick={prevTravel}

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -57,7 +57,11 @@ const TravelSection = () => {
 
   return (
     <section className={styles.travelSection}>
-      <button className={`${styles.navButton} ${styles.navButtonPrev}`} onClick={prevTravel}>
+      <button
+        className={`${styles.navButton} ${styles.navButtonPrev}`}
+        onClick={prevTravel}
+        aria-label="이전 여행 상품"
+      >
         <img src={chevronLeft} className={styles.navButtonIcon} />
       </button>
       <article className={styles.carousel}>
@@ -70,17 +74,33 @@ const TravelSection = () => {
             rel="noopener noreferrer"
           >
             <img src={option.image} className={styles.cardImage} />
-            <div className={styles.cardContent}>
-              <h3 className={`${styles.cardTitle} heading-3-text`}>
+            <div className={styles.cardContent} aria-live="polite">
+              <h3
+                className={`${styles.cardTitle} heading-3-text`}
+                aria-label={`${travelOptions.length}개의 여행 상품 중 ${
+                  currentIndex + 1
+                }번째 상품. ${option.departure} 출발. ${option.destination} 도착.`}
+                role="link"
+              >
                 {option.departure} - {option.destination}
               </h3>
               <p className={`${styles.cardType} body-text`}>{option.type}</p>
-              <p className={`${styles.cardPrice} body-text`}>KRW {option.price.toLocaleString()}</p>
+              <p
+                className={`${styles.cardPrice} body-text`}
+                aria-label={`가격 ${option.price.toLocaleString()}원. 선택하면 예약 페이지로 이동합니다.`}
+                role="link"
+              >
+                KRW {option.price.toLocaleString()}
+              </p>
             </div>
           </a>
         ))}
       </article>
-      <button className={`${styles.navButton} ${styles.navButtonNext}`} onClick={nextTravel}>
+      <button
+        className={`${styles.navButton} ${styles.navButtonNext}`}
+        onClick={nextTravel}
+        aria-label="다음 여행 상품"
+      >
         <img src={chevronRight} className={styles.navButtonIcon} />
       </button>
     </section>

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -55,37 +55,35 @@ const TravelSection = () => {
     setCurrentIndex((prevIndex) => (prevIndex - 1 + travelOptions.length) % travelOptions.length);
   };
 
-  const handleCardClick = (link: string) => {
-    window.open(link, '_blank', 'noopener,noreferrer');
-  };
-
   return (
-    <div className={styles.travelSection}>
+    <section className={styles.travelSection}>
       <button className={`${styles.navButton} ${styles.navButtonPrev}`} onClick={prevTravel}>
         <img src={chevronLeft} className={styles.navButtonIcon} />
       </button>
-      <div className={styles.carousel}>
+      <article className={styles.carousel}>
         {travelOptions.map((option, index) => (
-          <div
+          <a
             key={index}
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
-            onClick={() => handleCardClick(option.link)}
+            href={option.link}
+            target="_blank"
+            rel="noopener noreferrer"
           >
             <img src={option.image} className={styles.cardImage} />
             <div className={styles.cardContent}>
-              <p className={`${styles.cardTitle} heading-3-text`}>
+              <h3 className={`${styles.cardTitle} heading-3-text`}>
                 {option.departure} - {option.destination}
-              </p>
+              </h3>
               <p className={`${styles.cardType} body-text`}>{option.type}</p>
               <p className={`${styles.cardPrice} body-text`}>KRW {option.price.toLocaleString()}</p>
             </div>
-          </div>
+          </a>
         ))}
-      </div>
+      </article>
       <button className={`${styles.navButton} ${styles.navButtonNext}`} onClick={nextTravel}>
         <img src={chevronRight} className={styles.navButtonIcon} />
       </button>
-    </div>
+    </section>
   );
 };
 


### PR DESCRIPTION
호초 안녕하세요~~
스승님의 코드 리뷰를 받게 되어 큰 영광입니다
가이드가 있는 줄 모르고 주말 동안 열심히 알아봤는데 억울하네요
리뷰 잘 부탁드립니다!!!!!


## 🔥 결과

<!-- 개선 작업 후 모바일 낭독기를 사용해서 미션 페이지를 읽어보세요 -->

- 배포한 페이지 접근 경로(GitHub Pages):[수이](https://shuyeon.github.io/a11y-airline/)
- 스크린 리더 화면 녹화 영상

https://github.com/user-attachments/assets/72e256e7-f8d2-41d8-b671-b08134005c5e

https://github.com/user-attachments/assets/ad2a9acf-27df-4987-88b3-771d04dbb0ff




## ✅ 개선 작업 목록
**1 컴포넌트 접근성 개선 - 이미지 캐로셀**

- [x] 스크린 리더가 캐로셀의 전체 아이템 수를 읽을 수 있어야 합니다.
  - 01da27e47f1763dcc8d13daff1c11c56c64ef22d
- [x] 스크린 리더가 이미지 캐로셀 내 각 아이템 정보를 읽을 수 있어야 합니다.
  - [x] 여행지, 좌석 유형, 가격 정보를 한번에 읽을 수 있어야 합니다.
  - 4c54ca36fbe7bd504f58bdca2f09299c6a01ecb1
  - [x] 이전/다음 아이템으로 이동하고 현재 보이는 아이템의 정보를 읽을 수 있어야 합니다.
- [x] 각 아이템을 선택하면 각각에 맞는 링크로 이동할 수 있어야 합니다.

**2 페이지 접근성 개선**

- [x] 페이지를 하나의 문서로 읽을 수 있어야 합니다.
  - [x] 페이지에 적절한 제목(title)을 제공하세요. 제목은 페이지의 주요 내용을 간결하게 설명해야 합니다.
  - 4080815b4203dcb349b7141cbff1c6af5f47e6fb
  - [x] 페이지의 주요 영역을 시맨틱 태그를 사용해 명확히 구분해 주세요
  - 91ffa846db2404921b9fa2c022687a041fe08e4b
  - ef5c00c78403ca16a9be1a33cd422367e719dc5e
  - [x] 헤딩을 논리적인 순서로 사용해 페이지 구조를 명확히 해주세요
- [x] 키보드 사용자를 위해 페이지 최상단에 '본문으로 바로가기' 링크를 제공해 반복되는 메뉴를 건너뛸 수 있게 해주세요
  - 2e24c97ce361943038ebc5afb20738338064abbd
  - 
## 🧐 우리 팀의 접근성 체크리스트

아래는 픽잇 프론트와 이야기한 픽잇 접근성 체크리스트입니다 확인 부탁드려요! 카멜이 정리해줬어용

저희 팀의 핵심 기능 플로우는 `식당 투표 열기 -> 가기 싫은 식당 소거하기 -> 가고 싶은 식당 투표하기 -> 투표 종료 후 식당 추천 결과 확인하기` 입니다. 그리고 실제 저희의 서비스를 보이스오버를 켜고 사용해보니, 시맨틱 태그나 음성 안내가 하나도 제대로 이루어지지않고 있어, 페이지의 플로우를 알기 힘듦을 알 수 있었습니다. 따라서 aria 속성과 시멘틱 태그, alt 속성 등을 적극적으로 활용하여 접근성을 개선해야함을 느꼈습니다.
따라서 차례차례 적용할 개선 사항을 정리해보니 다음과 같았습니다.
- [ ] 각 페이지의 시멘틱 태그를 의미있게 작성
- [ ] 논리적인 태그 순서 위계 정렬
- [ ] aria 속성 및 이미지에 alt 속성 등 적용
- [ ] 모달 포커스 트랩 적용
- [ ] lighthouse 의 접근성 지표 참고하여 추가 개선