### PR TITLE
[항공사 웹사이트의 컴포넌트 접근성 높이기] 아더(곽민준) 미션 제출합니다

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,15 +1,13 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>A11Y AIRLINE - 항공권 예매</title>
+  </head>
 
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>React App</title>
-</head>
-
-<body>
-  <div id="root"></div>
-  <script type="module" src="/src/main.tsx"></script>
-</body>
-
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "deploy": "npm run build && npx gh-pages -d dist"
   },
   "author": "woowacourse",
-  "homepage": "https://{username}.github.io/a11y-airline",
+  "homepage": "https://mlnwns.github.io/a11y-airline",
   "license": "MIT",
   "dependencies": {
     "react": "^18.3.1",

--- a/src/App.module.css
+++ b/src/App.module.css
@@ -9,6 +9,22 @@
   margin: 0 auto;
 }
 
+.skipLink a {
+  position: absolute;
+  top: -40px;
+  left: 0;
+  background: #333333;
+  color: #fff;
+  padding: 8px 16px;
+  z-index: 100;
+  text-decoration: none;
+  transition: top 0.2s;
+}
+
+.skipLink a:focus {
+  top: 0;
+}
+
 .header {
   padding: 48px 24px 24px 24px;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,24 +8,24 @@ function App() {
   return (
     <div className={styles.app}>
       <Navigation />
-      <div className={styles.header}>
+      <header className={styles.header}>
         <h1 className={`${styles.title} heading-1-text`}>A11Y AIRLINE</h1>
         <p className="body-text">
           A11Y AIRLINE은 고객 여러분의 안전하고 쾌적한 여행을 위해 최선을 다하고 있습니다.
         </p>
-      </div>
-      <div id="main-content" className={styles.main}>
-        <div className={styles.flightBooking}>
+      </header>
+      <main id="main-content" className={styles.main}>
+        <section className={styles.flightBooking}>
           <FlightBooking />
-        </div>
-        <div className={styles.travelSection}>
-          <h1 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h1>
+        </section>
+        <section className={styles.travelSection}>
+          <h2 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h2>
           <TravelSection />
-        </div>
-      </div>
-      <div className={styles.footer}>
+        </section>
+      </main>
+      <footer className={styles.footer}>
         <p className="body-text">&copy; A11Y AIRLINE</p>
-      </div>
+      </footer>
       {/* 추가 CHALLENGE: 모달 포커스 트랩 */}
       {/* <PromotionModal /> */}
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,9 @@ import TravelSection from './components/TravelSection';
 function App() {
   return (
     <div className={styles.app}>
+      <div className={styles.skipLink}>
+        <a href="#main-content">본문으로 바로가기</a>
+      </div>
       <Navigation />
       <header className={styles.header}>
         <h1 className={`${styles.title} heading-1-text`}>A11Y AIRLINE</h1>

--- a/src/components/TravelSection.module.css
+++ b/src/components/TravelSection.module.css
@@ -19,6 +19,13 @@
   height: 246px;
 }
 
+.carouselCardButton {
+  width: 100%;
+  height: 100%;
+  border: none;
+  padding: 0;
+}
+
 .cardActive {
   display: block;
 }
@@ -39,6 +46,7 @@
   bottom: 0;
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.9) 26%, rgba(255, 255, 255, 0) 100%);
   padding: 24px 16px;
+  text-align: left;
 }
 
 .cardTitle {

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -15,7 +15,6 @@ interface TravelOption {
   price: number;
   image: string;
   link: string;
-  carouselItemLabel: string;
 }
 
 const travelOptions: TravelOption[] = [
@@ -25,8 +24,7 @@ const travelOptions: TravelOption[] = [
     type: '일반석 왕복',
     price: 1121600,
     image: travelItem01,
-    link: 'https://koreanairkp.kaltour.com/ProductOverseas/OverseasList?TOURTYP=KALPAK&PKGBRA=KP&PKGARE=E5&REGNB1=%uC720%uB7FD&REGNB2=%uC911%uB3D9&REGTOP=1',
-    carouselItemLabel: '3개의 여행 상품 중 첫 번째 상품'
+    link: 'https://koreanairkp.kaltour.com/ProductOverseas/OverseasList?TOURTYP=KALPAK&PKGBRA=KP&PKGARE=E5&REGNB1=%uC720%uB7FD&REGNB2=%uC911%uB3D9&REGTOP=1'
   },
   {
     departure: '서울/인천',
@@ -34,8 +32,7 @@ const travelOptions: TravelOption[] = [
     type: '일반석 왕복',
     price: 1515200,
     image: travelItem02,
-    link: 'https://koreanairkp.kaltour.com/ProductOverseas/OverseasView?pkgpnh=KP44129',
-    carouselItemLabel: '3개의 여행 상품 중 두 번째 상품'
+    link: 'https://koreanairkp.kaltour.com/ProductOverseas/OverseasView?pkgpnh=KP44129'
   },
   {
     departure: '서울/인천',
@@ -43,8 +40,7 @@ const travelOptions: TravelOption[] = [
     type: '일반석 왕복',
     price: 1415800,
     image: travelItem03,
-    link: 'https://koreanairkp.kaltour.com/ProductOverseas/OverseasView?pkgpnh=KP41216',
-    carouselItemLabel: '3개의 여행 상품 중 세 번째 상품'
+    link: 'https://koreanairkp.kaltour.com/ProductOverseas/OverseasView?pkgpnh=KP41216'
   }
 ];
 
@@ -72,7 +68,9 @@ const TravelSection = () => {
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
             aria-live="polite"
           >
-            <span className="visually-hidden">{option.carouselItemLabel}</span>
+            <span className="visually-hidden">{`${travelOptions.length}개의 여행 상품 중 ${
+              currentIndex + 1
+            }번째 상품`}</span>
             <button
               type="button"
               onClick={() => handleCardClick(option.link)}

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -70,27 +70,47 @@ const TravelSection = () => {
           <div
             key={index}
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
-            onClick={() => handleCardClick(option.link)}
           >
             <span aria-live="polite" className="visually-hidden">
               {option.carouselItemLabel}
             </span>
-            <img src={option.image} className={styles.cardImage} alt={`${option.destination}`} />
-            <div className={styles.cardContent}>
-              <p className={`${styles.cardTitle} heading-3-text`}>
-                {option.departure} - {option.destination}
-              </p>
-              <p className={`${styles.cardType} body-text`}>{option.type}</p>
-              <p className={`${styles.cardPrice} body-text`}>KRW {option.price.toLocaleString()}</p>
-            </div>
+            <button
+              type="button"
+              onClick={() => handleCardClick(option.link)}
+              className={styles.carouselCardButton}
+              aria-label={`${option.departure} 출발 ${option.destination} 도착. ${option.type} 가격 ${option.price}원. 선택하면 예약 페이지로 이동합니다.`}
+            >
+              <img
+                src={option.image}
+                className={styles.cardImage}
+                alt={`${option.destination} 이미지`}
+              />
+              <div className={styles.cardContent}>
+                <p className={`${styles.cardTitle} heading-3-text`}>
+                  {option.departure} - {option.destination}
+                </p>
+                <p className={`${styles.cardType} body-text`}>{option.type}</p>
+                <p className={`${styles.cardPrice} body-text`}>
+                  KRW {option.price.toLocaleString()}
+                </p>
+              </div>
+            </button>
           </div>
         ))}
       </div>
-      <button className={`${styles.navButton} ${styles.navButtonPrev}`} onClick={prevTravel}>
-        <img src={chevronLeft} className={styles.navButtonIcon} />
+      <button
+        type="button"
+        className={`${styles.navButton} ${styles.navButtonPrev}`}
+        onClick={prevTravel}
+      >
+        <img src={chevronLeft} className={styles.navButtonIcon} alt="" />
       </button>
-      <button className={`${styles.navButton} ${styles.navButtonNext}`} onClick={nextTravel}>
-        <img src={chevronRight} className={styles.navButtonIcon} />
+      <button
+        type="button"
+        className={`${styles.navButton} ${styles.navButtonNext}`}
+        onClick={nextTravel}
+      >
+        <img src={chevronRight} className={styles.navButtonIcon} alt="" />
       </button>
     </div>
   );

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -102,6 +102,7 @@ const TravelSection = () => {
         type="button"
         className={`${styles.navButton} ${styles.navButtonPrev}`}
         onClick={prevTravel}
+        aria-label="이전 여행 상품"
       >
         <img src={chevronLeft} className={styles.navButtonIcon} alt="" />
       </button>
@@ -109,6 +110,7 @@ const TravelSection = () => {
         type="button"
         className={`${styles.navButton} ${styles.navButtonNext}`}
         onClick={nextTravel}
+        aria-label="다음 여행 상품"
       >
         <img src={chevronRight} className={styles.navButtonIcon} alt="" />
       </button>

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -15,6 +15,7 @@ interface TravelOption {
   price: number;
   image: string;
   link: string;
+  carouselItemLabel: string;
 }
 
 const travelOptions: TravelOption[] = [
@@ -24,7 +25,8 @@ const travelOptions: TravelOption[] = [
     type: '일반석 왕복',
     price: 1121600,
     image: travelItem01,
-    link: 'https://koreanairkp.kaltour.com/ProductOverseas/OverseasList?TOURTYP=KALPAK&PKGBRA=KP&PKGARE=E5&REGNB1=%uC720%uB7FD&REGNB2=%uC911%uB3D9&REGTOP=1'
+    link: 'https://koreanairkp.kaltour.com/ProductOverseas/OverseasList?TOURTYP=KALPAK&PKGBRA=KP&PKGARE=E5&REGNB1=%uC720%uB7FD&REGNB2=%uC911%uB3D9&REGTOP=1',
+    carouselItemLabel: '3개의 여행 상품 중 첫 번째 상품'
   },
   {
     departure: '서울/인천',
@@ -32,7 +34,8 @@ const travelOptions: TravelOption[] = [
     type: '일반석 왕복',
     price: 1515200,
     image: travelItem02,
-    link: 'https://koreanairkp.kaltour.com/ProductOverseas/OverseasView?pkgpnh=KP44129'
+    link: 'https://koreanairkp.kaltour.com/ProductOverseas/OverseasView?pkgpnh=KP44129',
+    carouselItemLabel: '3개의 여행 상품 중 두 번째 상품'
   },
   {
     departure: '서울/인천',
@@ -40,7 +43,8 @@ const travelOptions: TravelOption[] = [
     type: '일반석 왕복',
     price: 1415800,
     image: travelItem03,
-    link: 'https://koreanairkp.kaltour.com/ProductOverseas/OverseasView?pkgpnh=KP41216'
+    link: 'https://koreanairkp.kaltour.com/ProductOverseas/OverseasView?pkgpnh=KP41216',
+    carouselItemLabel: '3개의 여행 상품 중 세 번째 상품'
   }
 ];
 
@@ -61,9 +65,6 @@ const TravelSection = () => {
 
   return (
     <div className={styles.travelSection}>
-      <button className={`${styles.navButton} ${styles.navButtonPrev}`} onClick={prevTravel}>
-        <img src={chevronLeft} className={styles.navButtonIcon} />
-      </button>
       <div className={styles.carousel}>
         {travelOptions.map((option, index) => (
           <div
@@ -71,7 +72,10 @@ const TravelSection = () => {
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
             onClick={() => handleCardClick(option.link)}
           >
-            <img src={option.image} className={styles.cardImage} />
+            <span aria-live="polite" className="visually-hidden">
+              {option.carouselItemLabel}
+            </span>
+            <img src={option.image} className={styles.cardImage} alt={`${option.destination}`} />
             <div className={styles.cardContent}>
               <p className={`${styles.cardTitle} heading-3-text`}>
                 {option.departure} - {option.destination}
@@ -82,6 +86,9 @@ const TravelSection = () => {
           </div>
         ))}
       </div>
+      <button className={`${styles.navButton} ${styles.navButtonPrev}`} onClick={prevTravel}>
+        <img src={chevronLeft} className={styles.navButtonIcon} />
+      </button>
       <button className={`${styles.navButton} ${styles.navButtonNext}`} onClick={nextTravel}>
         <img src={chevronRight} className={styles.navButtonIcon} />
       </button>

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -70,10 +70,9 @@ const TravelSection = () => {
           <div
             key={index}
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
+            aria-live="polite"
           >
-            <span aria-live="polite" className="visually-hidden">
-              {option.carouselItemLabel}
-            </span>
+            <span className="visually-hidden">{option.carouselItemLabel}</span>
             <button
               type="button"
               onClick={() => handleCardClick(option.link)}

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -61,9 +61,9 @@ const TravelSection = () => {
 
   return (
     <div className={styles.travelSection}>
-      <div className={styles.carousel}>
+      <ul className={styles.carousel}>
         {travelOptions.map((option, index) => (
-          <div
+          <li
             key={index}
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
             aria-live="polite"
@@ -92,9 +92,9 @@ const TravelSection = () => {
                 </p>
               </div>
             </button>
-          </div>
+          </li>
         ))}
-      </div>
+      </ul>
       <button
         type="button"
         className={`${styles.navButton} ${styles.navButtonPrev}`}


### PR DESCRIPTION
안녕하세요 다이앤!!! 🙇‍♂️ 이렇게 만나뵙게 되어 반갑습니다 ㅎㅎ
이번 미션 잘 부탁드립니다!!

## 결과

<!-- 개선 작업 후 모바일 낭독기를 사용해서 미션 페이지를 읽어보세요 -->

- **배포한 페이지 접근 경로 (GitHub Pages)** 
[mlnwns.github.io/a11y-airline](https://mlnwns.github.io/a11y-airline/)

### 스크린샷
<p align="center">
  <img width="45%" alt="메인 페이지 스크린샷" src="https://github.com/user-attachments/assets/8023023e-cb3a-48d0-bee7-9827e82b6928" />
  <img width="45%" alt="접근성 개선 스크린샷" src="https://github.com/user-attachments/assets/c10e8298-2611-4421-a360-a19cfe51c317" />
</p>

### 스크린 리더 화면 녹화 영상

#### 개선 전  
https://github.com/user-attachments/assets/37175435-52ba-4cbe-87d6-31c5f16b4ad4  

#### 개선 후  
https://github.com/user-attachments/assets/8318ef1e-5874-40bc-8cf6-9ed4bf6472f0



## ✅ 개선 작업 목록

<!-- 각 요구 사항을 위해 어떤 부분을 고민/학습해보았고, 결과적으로 어떤 개선 작업을 진행했는지 적어주세요-->

**1 컴포넌트 접근성 개선 - 이미지 캐로셀**

- [x] 스크린 리더가 캐로셀의 전체 아이템 수를 읽을 수 있어야 합니다.
- [x] 스크린 리더가 이미지 캐로셀 내 각 아이템 정보를 읽을 수 있어야 합니다.
  - [x] 여행지, 좌석 유형, 가격 정보를 한번에 읽을 수 있어야 합니다.
  - [x] 이전/다음 아이템으로 이동하고 현재 보이는 아이템의 정보를 읽을 수 있어야 합니다.
- [x] 각 아이템을 선택하면 각각에 맞는 링크로 이동할 수 있어야 합니다.

**2 페이지 접근성 개선**

- [x] 페이지를 하나의 문서로 읽을 수 있어야 합니다.
  - [x] 페이지에 적절한 제목(title)을 제공하세요. 제목은 페이지의 주요 내용을 간결하게 설명해야 합니다.
  - [x] 페이지의 주요 영역을 시맨틱 태그를 사용해 명확히 구분해 주세요
  - [x] 헤딩을 논리적인 순서로 사용해 페이지 구조를 명확히 해주세요
- [x] 키보드 사용자를 위해 페이지 최상단에 '본문으로 바로가기' 링크를 제공해 반복되는 메뉴를 건너뛸 수 있게 해주세요

## 🧐 팀 서비스의 접근성

<!--
우리 서비스에서 이런 부분의 접근성은 챙겨봐야겠다! 하는 체크리스트 v1을 만들고, 리뷰어와 의견을 나눠보세요
- 우리 팀 서비스에서 가장 중요하고 자주 사용되는 기능 플로우 1개를 선택하고 간단히 나열해 주세요 (예: 로그인 → 상품 검색 → 상품 선택 → 장바구니 추가 → 결제)
- 해당 플로우의 각 단계에 대해 다음 질문을 생각해 보세요.
  - 1. 화면을 볼 수 없는 사용자가 이 단계를 완료할 수 있는가?
  - 2. 이 단계에서 제공하는 정보나 지시 사항이 모든 사용자에게 명확한가?
- 질문에 대해 팀원들과 의견을 나눠본 것을 바탕으로, 우리 팀만의 접근성 체크리스트 v1을 만들고 리뷰어와 의견을 나눠보세요. (예: "모든 이미지에 적절한 대체 텍스트가 제공되는가?")
-->
[서비스 링크](moaon.co.kr)   

팀 서비스의 핵심 기능 플로우는 랜딩페이지 〉 프로젝트 탐색 〉 프로젝트 상세페이지 〉 프로젝트 내 아티클 탐색입니다.
보이스오버를 켠 후 서비스를 사용해본 결과, 사이트 접속 이후 로고를 읽는 과정에서 로고를 한 글자 한 글자 읽는 현상을 발견하였습니다.

또한, 플로우를 따라가다보니 프로젝트 하나에 대한 카드 정보를 읽는 과정에서 기술스택을 탭 한 번당 한 번씩 읽는 것을 겪었습니다. 기술스택이 30개 이상인 경우 탭을 30번 해야하므로 불편함이 상당히 클 것이라는 생각이 들었습니다.

클릭하면 무슨 일이 일어나는지에 대한 정보가 명확히 이루어지지 않아, 사용자가 사이트에 들어와서 어떤 작업을 할 수 있는것인지에 대해 제공하는 부분이 부족하다는 생각이 들었습니다. 

### 우리 팀만의 접근성 체크리스트 v1

1. 랜딩페이지
	•	로고가 적절한 대체 텍스트로 제공되는가? (한 글자씩 읽히는 현상 방지)
	•	메인 영역으로 건너뛸 수 있는 “본문으로 건너뛰기” 링크가 제공되는가?
	•	랜딩페이지에서 사용자가 할 수 있는 주요 작업(프로젝트 탐색 등)에 대해 명확히 안내되는가?

2. 프로젝트 탐색
	•	프로젝트 카드 전체가 링크인 경우, 클릭 시 어떤 페이지로 이동하는지 대체 텍스트 또는 라벨로 명확히 전달되는가?
	•	카드 내 각 요소(제목, 설명, 기술스택 등)의 탐색 순서가 논리적이고 혼동되지 않는가?
	•	기술스택처럼 항목이 많을 경우, 개별 요소가 탭키로 하나씩만 접근 가능한 대신 그룹화 또는 요약 제공이 되는가? (예: “기술스택 30개, 펼쳐보기”)

3. 프로젝트 상세페이지
	•	제목, 설명, 깃허브 링크 바로가기 등의 정보가 시각적 정보 없이도 충분히 이해 가능한가?
	•	캐러셀의 이동 버튼이 스크린 리더 사용자에게 명확히 전달되는가?
	•	클릭 가능한 버튼/링크가 어떤 동작을 수행하는지 스크린 리더 사용자에게 명확히 전달되는가? (예: “아티클 열기 버튼”)
	•	시각적 구분(컬러, 아이콘)만으로 전달되는 정보가 텍스트로도 제공되는가?

4. 프로젝트 내 아티클 탐색
	•	아티클 제목이 논리적인 계층 구조의 heading으로 제공되는가?
	•	아티클 페이지로 이동 동작이 시각장애 사용자에게도 분명히 전달되는가?