### PR TITLE
[항공사 웹사이트의 컴포넌트 접근성 높이기] 분주(황현정) 미션 제출합니다 

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,15 +1,19 @@
 <!doctype html>
 <html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>A11Y AIRLINE - 안전하고 쾌적한 여행을 위한 항공 예약 서비스</title>
+    <meta
+      name="description"
+      content="A11Y AIRLINE은 고객 여러분의 안전하고 쾌적한 여행을 위해 최선을 다하고 있습니다. 항공편 예약 및 여행 상품을 확인하세요."
+    />
+    <meta name="keywords" content="항공, 여행, 예약, A11Y, AIRLINE, 접근성" />
+    <meta name="author" content="A11Y AIRLINE" />
+  </head>
 
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>React App</title>
-</head>
-
-<body>
-  <div id="root"></div>
-  <script type="module" src="/src/main.tsx"></script>
-</body>
-
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "deploy": "npm run build && npx gh-pages -d dist"
   },
   "author": "woowacourse",
-  "homepage": "https://{username}.github.io/a11y-airline",
+  "homepage": "https://bunju20.github.io/a11y-airline",
   "license": "MIT",
   "dependencies": {
     "react": "^18.3.1",

--- a/src/App.module.css
+++ b/src/App.module.css
@@ -7,6 +7,25 @@
   flex-direction: column;
   background-color: #fff;
   margin: 0 auto;
+  position: relative;
+}
+
+.skipLink {
+  position: absolute;
+  top: -40px;
+  left: 6px;
+  background: #000;
+  color: #fff;
+  padding: 8px;
+  text-decoration: none;
+  z-index: 1000;
+  border-radius: 4px;
+  font-size: 14px;
+  font-weight: bold;
+}
+
+.skipLink:focus {
+  top: 6px;
 }
 
 .header {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,25 +7,36 @@ import TravelSection from './components/TravelSection';
 function App() {
   return (
     <div className={styles.app}>
-      <Navigation />
-      <div className={styles.header}>
-        <h1 className={`${styles.title} heading-1-text`}>A11Y AIRLINE</h1>
-        <p className="body-text">
-          A11Y AIRLINE은 고객 여러분의 안전하고 쾌적한 여행을 위해 최선을 다하고 있습니다.
-        </p>
-      </div>
-      <div id="main-content" className={styles.main}>
-        <div className={styles.flightBooking}>
+      <header role="banner">
+        <Navigation />
+        <div className={styles.header}>
+          <h1 className={`${styles.title} heading-1-text`}>A11Y AIRLINE</h1>
+          <p className="body-text">
+            A11Y AIRLINE은 고객 여러분의 안전하고 쾌적한 여행을 위해 최선을 다하고 있습니다.
+          </p>
+        </div>
+      </header>
+
+      <main id="main-content" className={styles.main} role="main">
+        <section className={styles.flightBooking} aria-labelledby="flight-booking-heading">
+          <h2 id="flight-booking-heading" className="visually-hidden">
+            항공편 예약
+          </h2>
           <FlightBooking />
-        </div>
-        <div className={styles.travelSection}>
-          <h1 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h1>
+        </section>
+
+        <section className={styles.travelSection} aria-labelledby="travel-section-heading">
+          <h2 id="travel-section-heading" className={`${styles.travelTitle} heading-2-text`}>
+            지금 떠나기 좋은 여행
+          </h2>
           <TravelSection />
-        </div>
-      </div>
-      <div className={styles.footer}>
+        </section>
+      </main>
+
+      <footer className={styles.footer} role="contentinfo">
         <p className="body-text">&copy; A11Y AIRLINE</p>
-      </div>
+      </footer>
+
       {/* 추가 CHALLENGE: 모달 포커스 트랩 */}
       {/* <PromotionModal /> */}
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,10 +25,8 @@ function App() {
           <FlightBooking />
         </section>
 
-        <section className={styles.travelSection} aria-labelledby="travel-section-heading">
-          <h2 id="travel-section-heading" className={`${styles.travelTitle} heading-2-text`}>
-            지금 떠나기 좋은 여행
-          </h2>
+        <section className={styles.travelSection}>
+          <h2 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h2>
           <TravelSection />
         </section>
       </main>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,9 @@ import TravelSection from './components/TravelSection';
 function App() {
   return (
     <div className={styles.app}>
+      <a href="#main-content" className={styles.skipLink}>
+        본문으로 바로가기
+      </a>
       <header role="banner">
         <Navigation />
         <div className={styles.header}>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,10 +18,7 @@ function App() {
       </header>
 
       <main id="main-content" className={styles.main} role="main">
-        <section className={styles.flightBooking} aria-labelledby="flight-booking-heading">
-          <h2 id="flight-booking-heading" className="visually-hidden">
-            항공편 예약
-          </h2>
+        <section className={styles.flightBooking}>
           <FlightBooking />
         </section>
 

--- a/src/components/TravelSection.module.css
+++ b/src/components/TravelSection.module.css
@@ -19,6 +19,17 @@
   height: 246px;
 }
 
+.card button {
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  width: 100%;
+  height: 100%;
+  cursor: pointer;
+  display: block;
+}
+
 .cardActive {
   display: block;
 }
@@ -39,6 +50,7 @@
   bottom: 0;
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.9) 26%, rgba(255, 255, 255, 0) 100%);
   padding: 24px 16px;
+  text-align: left;
 }
 
 .cardTitle {

--- a/src/components/TravelSection.module.css
+++ b/src/components/TravelSection.module.css
@@ -19,7 +19,7 @@
   height: 246px;
 }
 
-.card button {
+.cardLink {
   background: none;
   border: none;
   padding: 0;
@@ -28,6 +28,8 @@
   height: 100%;
   cursor: pointer;
   display: block;
+  text-decoration: none;
+  color: inherit;
 }
 
 .cardActive {

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -70,16 +70,24 @@ const TravelSection = () => {
             key={index}
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
             aria-hidden={index !== currentIndex}
-            onClick={() => handleCardClick(option.link)}
           >
-            <img src={option.image} className={styles.cardImage} />
-            <div className={styles.cardContent}>
-              <p className={`${styles.cardTitle} heading-3-text`}>
-                {option.departure} - {option.destination}
-              </p>
-              <p className={`${styles.cardType} body-text`}>{option.type}</p>
-              <p className={`${styles.cardPrice} body-text`}>KRW {option.price.toLocaleString()}</p>
-            </div>
+            <button
+              onClick={() => handleCardClick(option.link)}
+              aria-label={`${option.departure} 출발 ${option.destination} 도착, ${
+                option.type
+              }, 가격 ${option.price.toLocaleString()} 원. 선택하면 예약 페이지로 이동합니다.`}
+            >
+              <img src={option.image} className={styles.cardImage} alt="" />
+              <div className={styles.cardContent} aria-hidden="true">
+                <p className={`${styles.cardTitle} heading-3-text`}>
+                  {option.departure} - {option.destination}
+                </p>
+                <p className={`${styles.cardType} body-text`}>{option.type}</p>
+                <p className={`${styles.cardPrice} body-text`}>
+                  KRW {option.price.toLocaleString()}
+                </p>
+              </div>
+            </button>
           </li>
         ))}
       </ul>

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -7,6 +7,7 @@ import chevronLeft from '../assets/chevron-left.svg';
 import chevronRight from '../assets/chevron-right.svg';
 
 import styles from './TravelSection.module.css';
+import '../Accessibility.css';
 
 interface TravelOption {
   departure: string;
@@ -61,6 +62,7 @@ const TravelSection = () => {
 
   return (
     <div className={styles.travelSection}>
+      <p className="visually-hidden">{`${travelOptions.length}개의 여행 상품 중 ${currentIndex + 1}번째 상품`}</p>
       <button className={`${styles.navButton} ${styles.navButtonPrev}`} onClick={prevTravel}>
         <img src={chevronLeft} className={styles.navButtonIcon} />
       </button>

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -64,11 +64,11 @@ const TravelSection = () => {
     <div className={styles.travelSection}>
       <p className="visually-hidden">{`${travelOptions.length}개의 여행 상품 중 ${currentIndex + 1}번째 상품`}</p>
 
-      <ul className="travel-carousel">
+      <ul className={styles.carousel}>
         {travelOptions.map((option, index) => (
           <li
             key={index}
-            className={`travel-card ${index === currentIndex ? 'active' : ''}`}
+            className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
             aria-hidden={index !== currentIndex}
             onClick={() => handleCardClick(option.link)}
           >

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -63,14 +63,13 @@ const TravelSection = () => {
   return (
     <div className={styles.travelSection}>
       <p className="visually-hidden">{`${travelOptions.length}개의 여행 상품 중 ${currentIndex + 1}번째 상품`}</p>
-      <button className={`${styles.navButton} ${styles.navButtonPrev}`} onClick={prevTravel}>
-        <img src={chevronLeft} className={styles.navButtonIcon} />
-      </button>
-      <div className={styles.carousel}>
+
+      <ul className="travel-carousel">
         {travelOptions.map((option, index) => (
-          <div
+          <li
             key={index}
-            className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
+            className={`travel-card ${index === currentIndex ? 'active' : ''}`}
+            aria-hidden={index !== currentIndex}
             onClick={() => handleCardClick(option.link)}
           >
             <img src={option.image} className={styles.cardImage} />
@@ -81,11 +80,23 @@ const TravelSection = () => {
               <p className={`${styles.cardType} body-text`}>{option.type}</p>
               <p className={`${styles.cardPrice} body-text`}>KRW {option.price.toLocaleString()}</p>
             </div>
-          </div>
+          </li>
         ))}
-      </div>
-      <button className={`${styles.navButton} ${styles.navButtonNext}`} onClick={nextTravel}>
-        <img src={chevronRight} className={styles.navButtonIcon} />
+      </ul>
+
+      <button
+        className={`${styles.navButton} ${styles.navButtonPrev}`}
+        aria-label="이전 여행 상품"
+        onClick={prevTravel}
+      >
+        <img src={chevronLeft} className={styles.navButtonIcon} alt="" />
+      </button>
+      <button
+        className={`${styles.navButton} ${styles.navButtonNext}`}
+        aria-label="다음 여행 상품"
+        onClick={nextTravel}
+      >
+        <img src={chevronRight} className={styles.navButtonIcon} alt="" />
       </button>
     </div>
   );

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -56,13 +56,17 @@ const TravelSection = () => {
     setCurrentIndex((prevIndex) => (prevIndex - 1 + travelOptions.length) % travelOptions.length);
   };
 
-  const handleCardClick = (link: string) => {
-    window.open(link, '_blank', 'noopener,noreferrer');
-  };
+  const currentOption = travelOptions[currentIndex];
 
   return (
     <div className={styles.travelSection}>
-      <p className="visually-hidden">{`${travelOptions.length}개의 여행 상품 중 ${currentIndex + 1}번째 상품`}</p>
+      <div className="visually-hidden" aria-live="polite" aria-atomic="true">
+        {`${travelOptions.length}개의 여행 상품 중 ${currentIndex + 1}번째 상품: ${
+          currentOption.departure
+        } 출발 ${currentOption.destination} 도착, ${
+          currentOption.type
+        }, 가격 ${currentOption.price.toLocaleString('ko-KR')} 원`}
+      </div>
 
       <ul className={styles.carousel}>
         {travelOptions.map((option, index) => (
@@ -71,11 +75,13 @@ const TravelSection = () => {
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
             aria-hidden={index !== currentIndex}
           >
-            <button
-              onClick={() => handleCardClick(option.link)}
-              aria-label={`${option.departure} 출발 ${option.destination} 도착, ${
-                option.type
-              }, 가격 ${option.price.toLocaleString()} 원. 선택하면 예약 페이지로 이동합니다.`}
+            <a
+              href={option.link}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={styles.cardLink}
+              tabIndex={index === currentIndex ? 0 : -1}
+              aria-label={`${option.departure} 출발 ${option.destination} 도착, ${option.type}, 가격 ${option.price.toLocaleString('ko-KR')} 원`}
             >
               <img src={option.image} className={styles.cardImage} alt="" />
               <div className={styles.cardContent} aria-hidden="true">
@@ -84,10 +90,10 @@ const TravelSection = () => {
                 </h3>
                 <p className={`${styles.cardType} body-text`}>{option.type}</p>
                 <p className={`${styles.cardPrice} body-text`}>
-                  KRW {option.price.toLocaleString()}
+                  KRW {option.price.toLocaleString('ko-KR')}
                 </p>
               </div>
-            </button>
+            </a>
           </li>
         ))}
       </ul>

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -79,9 +79,9 @@ const TravelSection = () => {
             >
               <img src={option.image} className={styles.cardImage} alt="" />
               <div className={styles.cardContent} aria-hidden="true">
-                <p className={`${styles.cardTitle} heading-3-text`}>
+                <h3 className={`${styles.cardTitle} heading-3-text`}>
                   {option.departure} - {option.destination}
-                </p>
+                </h3>
                 <p className={`${styles.cardType} body-text`}>{option.type}</p>
                 <p className={`${styles.cardPrice} body-text`}>
                   KRW {option.price.toLocaleString()}


### PR DESCRIPTION
## 🔥 결과

- 배포한 페이지 접근 경로(GitHub Pages): https://bunju20.github.io/a11y-airline/
- 스크린 리더 화면 녹화 영상 (before / after)

**before**

https://github.com/user-attachments/assets/da44f9d3-8fe3-462f-86cc-d944dcb79c9b


**after**

https://github.com/user-attachments/assets/68bd9a10-d291-4985-be49-64d3710dd2aa

## ✅ 개선 작업 목록

<!-- 각 요구 사항을 위해 어떤 부분을 고민/학습해보았고, 결과적으로 어떤 개선 작업을 진행했는지 적어주세요-->

**1 컴포넌트 접근성 개선 - 이미지 캐로셀**

- [x] 스크린 리더가 캐로셀의 전체 아이템 수를 읽을 수 있어야 합니다.
- [x] 스크린 리더가 이미지 캐로셀 내 각 아이템 정보를 읽을 수 있어야 합니다.
  - [x] 여행지, 좌석 유형, 가격 정보를 한번에 읽을 수 있어야 합니다.
  - [x] 이전/다음 아이템으로 이동하고 현재 보이는 아이템의 정보를 읽을 수 있어야 합니다.
- [x] 각 아이템을 선택하면 각각에 맞는 링크로 이동할 수 있어야 합니다.

**2 페이지 접근성 개선**

- [x] 페이지를 하나의 문서로 읽을 수 있어야 합니다.
  - [x] 페이지에 적절한 제목(title)을 제공하세요. 제목은 페이지의 주요 내용을 간결하게 설명해야 합니다.
  - [x] 페이지의 주요 영역을 시맨틱 태그를 사용해 명확히 구분해 주세요
  - [x] 헤딩을 논리적인 순서로 사용해 페이지 구조를 명확히 해주세요
- [x] 키보드 사용자를 위해 페이지 최상단에 '본문으로 바로가기' 링크를 제공해 반복되는 메뉴를 건너뛸 수 있게 해주세요

## 🧐 우리 팀의 접근성 체크리스트

<img width="1980" height="148" alt="CleanShot 2025-09-30 at 13 16 04@2x" src="https://github.com/user-attachments/assets/2f807bf6-9c80-4fae-8653-aecce1535171" />

1. 각각의 방 정보를 확인할수 있는가?
2. 스크린 리더 사용자가 피드백의 통계를 한번에 확인할수 있는가?
3. 스크린 리더 사용자가 각각의 피드백 정보를 확인할 수 있는가?(닉네임, 좋아요 수, 피드백 내용, 날짜)
4. 모든 입력 필드에 적절한 레이블이 연결되어 있는가?
5. 스크린 리더 사용자가 답변 삭제 버튼을 인식할수 있는가?
6. 스크린 리더 사용자가 답변 달기 버튼을 인식할수 있는가?
7. 스크린 리더 사용자가 삭제 모달로 삭제할수있는가.

<!--
우리 서비스에서 이런 부분의 접근성은 챙겨봐야겠다! 하는 체크리스트 v1을 만들고, 리뷰어와 의견을 나눠보세요
- 우리 팀 서비스에서 가장 중요하고 자주 사용되는 기능 플로우 1개를 선택하고 간단히 나열해 주세요 (예: 로그인 → 상품 검색 → 상품 선택 → 장바구니 추가 → 결제)
- 해당 플로우의 각 단계에 대해 다음 질문을 생각해 보세요.
  - 1. 화면을 볼 수 없는 사용자가 이 단계를 완료할 수 있는가?
  - 2. 이 단계에서 제공하는 정보나 지시 사항이 모든 사용자에게 명확한가?
- 질문에 대해 팀원들과 의견을 나눠본 것을 바탕으로, 우리 팀만의 접근성 체크리스트 v1을 만들고 리뷰어와 의견을 나눠보세요. (예: "모든 이미지에 적절한 대체 텍스트가 제공되는가?")
-->
