### PR TITLE
[항공사 웹사이트의 컴포넌트 접근성 높이기] 니야(최수연) 미션 제출합니다

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,15 +1,13 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>A11Y AIRLINE - 접근성을 고려한 항공 예약 서비스</title>
+  </head>
 
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>React App</title>
-</head>
-
-<body>
-  <div id="root"></div>
-  <script type="module" src="/src/main.tsx"></script>
-</body>
-
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "deploy": "npm run build && npx gh-pages -d dist"
   },
   "author": "woowacourse",
-  "homepage": "https://{username}.github.io/a11y-airline",
+  "homepage": "https://sooyeoniya.github.io/a11y-airline",
   "license": "MIT",
   "dependencies": {
     "react": "^18.3.1",

--- a/src/App.module.css
+++ b/src/App.module.css
@@ -40,3 +40,18 @@
   background-color: white;
   text-align: center;
 }
+
+.skipLink {
+  position: absolute;
+  top: 0;
+  left: 0;
+  transform: translateY(-100%);
+  padding: 8px 12px;
+  background: #000;
+  color: #fff;
+  z-index: 1000;
+}
+
+.skipLink:focus {
+  transform: translateY(0);
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,24 +8,24 @@ function App() {
   return (
     <div className={styles.app}>
       <Navigation />
-      <div className={styles.header}>
+      <header className={styles.header}>
         <h1 className={`${styles.title} heading-1-text`}>A11Y AIRLINE</h1>
         <p className="body-text">
           A11Y AIRLINE은 고객 여러분의 안전하고 쾌적한 여행을 위해 최선을 다하고 있습니다.
         </p>
-      </div>
-      <div id="main-content" className={styles.main}>
-        <div className={styles.flightBooking}>
+      </header>
+      <main id="main-content" className={styles.main}>
+        <section className={styles.flightBooking}>
           <FlightBooking />
-        </div>
-        <div className={styles.travelSection}>
+        </section>
+        <section className={styles.travelSection}>
           <h1 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h1>
           <TravelSection />
-        </div>
-      </div>
-      <div className={styles.footer}>
+        </section>
+      </main>
+      <footer className={styles.footer}>
         <p className="body-text">&copy; A11Y AIRLINE</p>
-      </div>
+      </footer>
       {/* 추가 CHALLENGE: 모달 포커스 트랩 */}
       {/* <PromotionModal /> */}
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,9 @@ import TravelSection from './components/TravelSection';
 function App() {
   return (
     <div className={styles.app}>
+      <a href="#main-content" className={styles.skipLink}>
+        본문으로 바로가기
+      </a>
       <Navigation />
       <header className={styles.header}>
         <h1 className={`${styles.title} heading-1-text`}>A11Y AIRLINE</h1>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,7 @@ function App() {
           <FlightBooking />
         </section>
         <section className={styles.travelSection}>
-          <h1 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h1>
+          <h2 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h2>
           <TravelSection />
         </section>
       </main>

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -73,6 +73,12 @@ const TravelSection = () => {
             key={index}
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
             onClick={() => handleCardClick(option.link)}
+            role="button"
+            aria-label={`${option.departure} 출발 ${option.destination} 도착. ${
+              option.type
+            }. 가격 ${Math.floor(option.price / 10000)}만 ${(
+              option.price % 10000
+            ).toLocaleString()}원. 선택하면 예약 페이지로 이동합니다.`}
           >
             <img src={option.image} className={styles.cardImage} />
             <div className={styles.cardContent}>

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -67,17 +67,10 @@ const TravelSection = () => {
 
   return (
     <div className={styles.travelSection}>
-      <span className="visually-hidden" role="status">
-        {`${travelOptions.length}개의 여행 상품 중 ${currentIndex + 1}번째 상품`}
-      </span>
-      <button
-        className={`${styles.navButton} ${styles.navButtonPrev}`}
-        onClick={prevTravel}
-        aria-label="이전 여행 상품"
-      >
-        <img src={chevronLeft} className={styles.navButtonIcon} alt="이전" />
-      </button>
       <div className={styles.carousel} aria-live="polite">
+        <span className="visually-hidden">
+          {`${travelOptions.length}개의 여행 상품 중 ${currentIndex + 1}번째 상품`}
+        </span>
         {travelOptions.map((option, index) => (
           <div
             key={index}
@@ -97,6 +90,13 @@ const TravelSection = () => {
           </div>
         ))}
       </div>
+      <button
+        className={`${styles.navButton} ${styles.navButtonPrev}`}
+        onClick={prevTravel}
+        aria-label="이전 여행 상품"
+      >
+        <img src={chevronLeft} className={styles.navButtonIcon} alt="이전" />
+      </button>
       <button
         className={`${styles.navButton} ${styles.navButtonNext}`}
         onClick={nextTravel}

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -76,12 +76,6 @@ const TravelSection = () => {
             key={index}
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
             onClick={() => handleCardClick(option.link)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault();
-                handleCardClick(option.link);
-              }
-            }}
             aria-label={getTravelInfo(option)}
           >
             <img

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -72,7 +72,7 @@ const TravelSection = () => {
           {`${travelOptions.length}개의 여행 상품 중 ${currentIndex + 1}번째 상품`}
         </span>
         {travelOptions.map((option, index) => (
-          <div
+          <button
             key={index}
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
             onClick={() => handleCardClick(option.link)}
@@ -82,7 +82,6 @@ const TravelSection = () => {
                 handleCardClick(option.link);
               }
             }}
-            role="button"
             aria-label={getTravelInfo(option)}
           >
             <img
@@ -97,7 +96,7 @@ const TravelSection = () => {
               <p className={`${styles.cardType} body-text`}>{option.type}</p>
               <p className={`${styles.cardPrice} body-text`}>KRW {option.price.toLocaleString()}</p>
             </div>
-          </div>
+          </button>
         ))}
       </div>
       <button

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -60,9 +60,9 @@ const TravelSection = () => {
   };
 
   const getTravelInfo = (option: TravelOption) => {
-    return `${option.departure} 출발 ${option.destination} 도착. ${option.type}. 가격 ${Math.floor(
-      option.price / 10000
-    )}만 ${(option.price % 10000).toLocaleString()}원. 선택하면 예약 페이지로 이동합니다.`;
+    return `${option.departure} 출발 ${option.destination} 도착. ${
+      option.type
+    }. 가격 ${option.price.toLocaleString()}원. 선택하면 예약 페이지로 이동합니다.`;
   };
 
   return (

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -59,6 +59,12 @@ const TravelSection = () => {
     window.open(link, '_blank', 'noopener,noreferrer');
   };
 
+  const getTravelInfo = (option: TravelOption) => {
+    return `${option.departure} 출발 ${option.destination} 도착. ${option.type}. 가격 ${Math.floor(
+      option.price / 10000
+    )}만 ${(option.price % 10000).toLocaleString()}원. 선택하면 예약 페이지로 이동합니다.`;
+  };
+
   return (
     <div className={styles.travelSection}>
       <span className="visually-hidden" role="status">
@@ -78,11 +84,7 @@ const TravelSection = () => {
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
             onClick={() => handleCardClick(option.link)}
             role="button"
-            aria-label={`${option.departure} 출발 ${option.destination} 도착. ${
-              option.type
-            }. 가격 ${Math.floor(option.price / 10000)}만 ${(
-              option.price % 10000
-            ).toLocaleString()}원. 선택하면 예약 페이지로 이동합니다.`}
+            aria-label={getTravelInfo(option)}
           >
             <img src={option.image} className={styles.cardImage} />
             <div className={styles.cardContent}>

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -61,6 +61,9 @@ const TravelSection = () => {
 
   return (
     <div className={styles.travelSection}>
+      <span className="visually-hidden" role="status">
+        {`${travelOptions.length}개의 여행 상품 중 ${currentIndex + 1}번째 상품`}
+      </span>
       <button className={`${styles.navButton} ${styles.navButtonPrev}`} onClick={prevTravel}>
         <img src={chevronLeft} className={styles.navButtonIcon} />
       </button>

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -64,10 +64,14 @@ const TravelSection = () => {
       <span className="visually-hidden" role="status">
         {`${travelOptions.length}개의 여행 상품 중 ${currentIndex + 1}번째 상품`}
       </span>
-      <button className={`${styles.navButton} ${styles.navButtonPrev}`} onClick={prevTravel}>
-        <img src={chevronLeft} className={styles.navButtonIcon} />
+      <button
+        className={`${styles.navButton} ${styles.navButtonPrev}`}
+        onClick={prevTravel}
+        aria-label="이전 여행 상품"
+      >
+        <img src={chevronLeft} className={styles.navButtonIcon} alt="이전" />
       </button>
-      <div className={styles.carousel}>
+      <div className={styles.carousel} aria-live="polite">
         {travelOptions.map((option, index) => (
           <div
             key={index}
@@ -91,8 +95,12 @@ const TravelSection = () => {
           </div>
         ))}
       </div>
-      <button className={`${styles.navButton} ${styles.navButtonNext}`} onClick={nextTravel}>
-        <img src={chevronRight} className={styles.navButtonIcon} />
+      <button
+        className={`${styles.navButton} ${styles.navButtonNext}`}
+        onClick={nextTravel}
+        aria-label="다음 여행 상품"
+      >
+        <img src={chevronRight} className={styles.navButtonIcon} alt="다음" />
       </button>
     </div>
   );

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -85,7 +85,11 @@ const TravelSection = () => {
             role="button"
             aria-label={getTravelInfo(option)}
           >
-            <img src={option.image} className={styles.cardImage} />
+            <img
+              src={option.image}
+              className={styles.cardImage}
+              alt={`${option.destination} 여행지 이미지`}
+            />
             <div className={styles.cardContent}>
               <p className={`${styles.cardTitle} heading-3-text`}>
                 {option.departure} - {option.destination}

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -76,6 +76,12 @@ const TravelSection = () => {
             key={index}
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
             onClick={() => handleCardClick(option.link)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                handleCardClick(option.link);
+              }
+            }}
             role="button"
             aria-label={getTravelInfo(option)}
           >


### PR DESCRIPTION
안녕하세요, 재오! 니야입니다. 😃
접근성 개인 미션 제출하겠습니다! 

제가 현재 개발하고 있는 커피빵 서비스에 대한 접근성 체크리스트도 작성해봤는데,
이 부분에 있어서도 피드백 주시면 감사하겠습니다 🙇🏻‍♀️

## 🔥 결과

<!-- 개선 작업 후 모바일 낭독기를 사용해서 미션 페이지를 읽어보세요 -->

- 배포한 페이지 접근 경로(GitHub Pages): https://sooyeoniya.github.io/a11y-airline/
- 스크린 리더 화면 녹화 영상 (before / after)

### before

<img width="335" height="114" alt="접근성 개선 전" src="https://github.com/user-attachments/assets/f9200e81-1d52-40f7-9014-409b12bacf4e" />

https://github.com/user-attachments/assets/49ca0fb5-009c-463f-8ebe-7ba61b2614ca

### after

<img width="348" height="113" alt="접근성 개선 후" src="https://github.com/user-attachments/assets/03a3be40-8cbf-4e03-9a33-b29f8504f2a2" />

https://github.com/user-attachments/assets/e0569396-fc31-4255-ab32-cd08b653fac0

https://github.com/user-attachments/assets/8a836350-ba7b-4bf5-b45a-487d58afabea

https://github.com/user-attachments/assets/62b7ad50-be21-4276-85a7-66b3ae6042b4

## ✅ 개선 작업 목록

<!-- 각 요구 사항을 위해 어떤 부분을 고민/학습해보았고, 결과적으로 어떤 개선 작업을 진행했는지 적어주세요-->

**1 컴포넌트 접근성 개선 - 이미지 캐로셀**

- [x] 스크린 리더가 캐로셀의 전체 아이템 수를 읽을 수 있어야 합니다. (https://github.com/woowacourse/a11y-airline/pull/154/commits/ce2b3440d490c32c3210a5fe97c2202799b6a192)
- [x] 스크린 리더가 이미지 캐로셀 내 각 아이템 정보를 읽을 수 있어야 합니다.
  - [x] 여행지, 좌석 유형, 가격 정보를 한번에 읽을 수 있어야 합니다. (https://github.com/woowacourse/a11y-airline/pull/154/commits/56cb8ea004e403537f04633f05799a39b4bc6b96)
  - [x] 이전/다음 아이템으로 이동하고 현재 보이는 아이템의 정보를 읽을 수 있어야 합니다. (https://github.com/woowacourse/a11y-airline/pull/154/commits/3b4b5bbd695c6cea8513823495a8722b96a069ca)
- [x] 각 아이템을 선택하면 각각에 맞는 링크로 이동할 수 있어야 합니다. (https://github.com/woowacourse/a11y-airline/pull/154/commits/f70641a30472390d23912082dc97bf588b284ffd)

**2 페이지 접근성 개선**

- [x] 페이지를 하나의 문서로 읽을 수 있어야 합니다.
  - [x] 페이지에 적절한 제목(title)을 제공하세요. 제목은 페이지의 주요 내용을 간결하게 설명해야 합니다. (https://github.com/woowacourse/a11y-airline/pull/154/commits/dbe5a6bcbc8e87f25f6e659449efdf9b512cf9be)
  - [x] 페이지의 주요 영역을 시맨틱 태그를 사용해 명확히 구분해 주세요 (https://github.com/woowacourse/a11y-airline/pull/154/commits/cc0dbf273a09a04bd4fbf921d92b4a7d276a0201)
  - [x] 헤딩을 논리적인 순서로 사용해 페이지 구조를 명확히 해주세요 (https://github.com/woowacourse/a11y-airline/pull/154/commits/4625ab5185e01d7692b84deb1bb5939fee59ae38)
- [x] 키보드 사용자를 위해 페이지 최상단에 '본문으로 바로가기' 링크를 제공해 반복되는 메뉴를 건너뛸 수 있게 해주세요 (https://github.com/woowacourse/a11y-airline/pull/154/commits/46588feedff1a65a6db769d2f08adeef2644e136)

## 🧐 커피빵 서비스 접근성 체크리스트 v1

<!--
우리 서비스에서 이런 부분의 접근성은 챙겨봐야겠다! 하는 체크리스트 v1을 만들고, 리뷰어와 의견을 나눠보세요
- 우리 팀 서비스에서 가장 중요하고 자주 사용되는 기능 플로우 1개를 선택하고 간단히 나열해 주세요 (예: 로그인 → 상품 검색 → 상품 선택 → 장바구니 추가 → 결제)
- 해당 플로우의 각 단계에 대해 다음 질문을 생각해 보세요.
  - 1. 화면을 볼 수 없는 사용자가 이 단계를 완료할 수 있는가?
  - 2. 이 단계에서 제공하는 정보나 지시 사항이 모든 사용자에게 명확한가?
- 질문에 대해 팀원들과 의견을 나눠본 것을 바탕으로, 우리 팀만의 접근성 체크리스트 v1을 만들고 리뷰어와 의견을 나눠보세요. (예: "모든 이미지에 적절한 대체 텍스트가 제공되는가?")
-->

### 📋 주요 기능 플로우
**커피빵 게임 참여 플로우**: 홈 → 방 생성/참가 → 닉네임 입력 → 메뉴 선택 → 로비 → 미니게임 플레이 → 룰렛 → 당첨 결과 확인

### 🔍 접근성 체크리스트

#### **1단계: 홈 화면**
- [ ] **화면을 볼 수 없는 사용자가 방 만들기/참가하기를 구분할 수 있는가?**
- [ ] **초기 방문자를 위한 스플래시 화면이 스크린 리더 사용자에게 적절한가?**
#### **2단계: 닉네임 입력**
- [ ] **닉네임 중복 검사 결과를 스크린 리더가 알 수 있는가?**
- [ ] **입력 오류 시 명확한 오류 메시지가 제공되는가?**
#### **3단계: 메뉴 선택**
- [ ] **메뉴 이미지만으로 선택할 수 있는가?**
#### **4단계: 로비 (게임 준비)**
- [ ] **참가자, 룰렛, 미니게임 탭 간 전환이 가능한가?**
- [ ] **각 참가자의 준비 상태를 스크린 리더가 알 수 있는가?**
- [ ] **호스트/게스트 역할에 따른 버튼 차이가 명확한가?**
#### **5단계: 미니게임 플레이**
- [ ] **카드 선택 게임에서 카드가 스크린 리더로 구분 가능한가?**
- [ ] **게임 진행 상황과 타이머 정보가 접근 가능한가?**
- [ ] **게임 결과를 텍스트로 확인할 수 있는가?**
#### **6단계: 룰렛**
- [ ] **룰렛 회전 상태를 스크린 리더가 알 수 있는가?**
- [ ] **각 참가자의 확률 정보가 접근 가능한가?**
- [ ] **당첨자 발표를 스크린 리더가 인식할 수 있는가?**
#### **7단계: 당첨 결과 확인**
- [ ] **당첨자 결과와 주문 리스트가 스크린 리더로 읽을 수 있는가?**
- [ ] **게임 종료 후 다음 액션(새 게임, 방 나가기 등)이 명확한가?**