### PR TITLE
[항공사 웹사이트의 컴포넌트 접근성 높이기] 다이앤(고다은) 미션 제출합니다 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+.cursor/*

--- a/index.html
+++ b/index.html
@@ -1,15 +1,13 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>A11Y AIRLINE - 항공편 예약 및 여행 상품</title>
+  </head>
 
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>React App</title>
-</head>
-
-<body>
-  <div id="root"></div>
-  <script type="module" src="/src/main.tsx"></script>
-</body>
-
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "deploy": "npm run build && npx gh-pages -d dist"
   },
   "author": "woowacourse",
-  "homepage": "https://{username}.github.io/a11y-airline",
+  "homepage": "https://Daeun-100.github.io/a11y-airline",
   "license": "MIT",
   "dependencies": {
     "react": "^18.3.1",

--- a/src/App.module.css
+++ b/src/App.module.css
@@ -40,3 +40,20 @@
   background-color: white;
   text-align: center;
 }
+
+.skipLink {
+  position: absolute;
+  top: -40px;
+  left: 6px;
+  background: #1f6feb;
+  color: white;
+  padding: 8px;
+  text-decoration: none;
+  border-radius: 4px;
+  z-index: 1000;
+  transition: top 0.3s;
+}
+
+.skipLink:focus {
+  top: 6px;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,24 +8,24 @@ function App() {
   return (
     <div className={styles.app}>
       <Navigation />
-      <div className={styles.header}>
+      <header className={styles.header}>
         <h1 className={`${styles.title} heading-1-text`}>A11Y AIRLINE</h1>
         <p className="body-text">
           A11Y AIRLINE은 고객 여러분의 안전하고 쾌적한 여행을 위해 최선을 다하고 있습니다.
         </p>
-      </div>
-      <div id="main-content" className={styles.main}>
-        <div className={styles.flightBooking}>
+      </header>
+      <main id="main-content" className={styles.main}>
+        <section className={styles.flightBooking}>
           <FlightBooking />
-        </div>
-        <div className={styles.travelSection}>
-          <h1 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h1>
+        </section>
+        <section className={styles.travelSection}>
+          <h2 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h2>
           <TravelSection />
-        </div>
-      </div>
-      <div className={styles.footer}>
+        </section>
+      </main>
+      <footer className={styles.footer}>
         <p className="body-text">&copy; A11Y AIRLINE</p>
-      </div>
+      </footer>
       {/* 추가 CHALLENGE: 모달 포커스 트랩 */}
       {/* <PromotionModal /> */}
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,9 @@ import TravelSection from './components/TravelSection';
 function App() {
   return (
     <div className={styles.app}>
+      <a href="#main-content" className={styles.skipLink}>
+        본문으로 바로가기
+      </a>
       <Navigation />
       <header className={styles.header}>
         <h1 className={`${styles.title} heading-1-text`}>A11Y AIRLINE</h1>

--- a/src/components/FlightBooking.module.css
+++ b/src/components/FlightBooking.module.css
@@ -61,17 +61,3 @@
   border-radius: 4px;
   cursor: pointer;
 }
-
-.visually-hidden {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  margin: -1px;
-  border: 0;
-  padding: 0;
-
-  white-space: nowrap;
-  clip-path: inset(100%);
-  clip: rect(0 0 0 0);
-  overflow: hidden;
-}

--- a/src/components/FlightBooking.module.css
+++ b/src/components/FlightBooking.module.css
@@ -5,51 +5,20 @@
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
 }
 
+.flightBooking h2 {
+  margin-bottom: 16px;
+}
+
 .passengerLabel {
   display: flex;
   align-items: center;
-}
-
-.helpIconWrapper {
-  position: relative;
-  margin-left: 5px;
-  cursor: pointer;
-}
-
-.helpIcon {
-  width: 16px;
-  height: 16px;
-}
-
-.tooltip {
-  position: absolute;
-  bottom: 100%;
-  left: 50%;
-  transform: translateX(-50%);
-  background-color: #333;
-  color: white;
-  padding: 5px 10px;
-  border-radius: 4px;
-  font-size: 12px;
-  white-space: nowrap;
-  z-index: 1;
-}
-
-.tooltip::after {
-  content: '';
-  position: absolute;
-  top: 100%;
-  left: 50%;
-  border-width: 5px;
-  border-style: solid;
-  border-color: #333 transparent transparent transparent;
 }
 
 .passengerCount {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 15px;
+  margin-bottom: 16px;
 }
 
 .passengerCount span {
@@ -67,7 +36,6 @@
   border-radius: 16px;
   border: 1px solid #c0c0c0;
   background-color: #fff;
-  font-size: 18px;
   cursor: pointer;
   display: flex;
   justify-content: center;
@@ -92,4 +60,17 @@
   border: none;
   border-radius: 4px;
   cursor: pointer;
+}
+
+.visuallyHidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  border: 0;
+  padding: 0;
+  white-space: nowrap;
+  clip-path: inset(100%);
+  clip: rect(0 0 0 0);
+  overflow: hidden;
 }

--- a/src/components/FlightBooking.module.css
+++ b/src/components/FlightBooking.module.css
@@ -1,58 +1,27 @@
-.flightBooking {
+.flight-booking {
   background-color: white;
   border-radius: 8px;
   padding: 20px;
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
 }
 
-.passengerLabel {
+.flight-booking h2 {
+  margin-bottom: 16px;
+}
+
+.passenger-label {
   display: flex;
   align-items: center;
 }
 
-.helpIconWrapper {
-  position: relative;
-  margin-left: 5px;
-  cursor: pointer;
-}
-
-.helpIcon {
-  width: 16px;
-  height: 16px;
-}
-
-.tooltip {
-  position: absolute;
-  bottom: 100%;
-  left: 50%;
-  transform: translateX(-50%);
-  background-color: #333;
-  color: white;
-  padding: 5px 10px;
-  border-radius: 4px;
-  font-size: 12px;
-  white-space: nowrap;
-  z-index: 1;
-}
-
-.tooltip::after {
-  content: '';
-  position: absolute;
-  top: 100%;
-  left: 50%;
-  border-width: 5px;
-  border-style: solid;
-  border-color: #333 transparent transparent transparent;
-}
-
-.passengerCount {
+.passenger-count {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 15px;
+  margin-bottom: 16px;
 }
 
-.passengerCount span {
+.passenger-count span {
   font-weight: 700;
 }
 
@@ -67,7 +36,6 @@
   border-radius: 16px;
   border: 1px solid #c0c0c0;
   background-color: #fff;
-  font-size: 18px;
   cursor: pointer;
   display: flex;
   justify-content: center;
@@ -84,7 +52,7 @@
   padding: 0 16px;
 }
 
-.searchButton {
+.search-button {
   width: 100%;
   padding: 10px;
   background-color: #333;
@@ -92,4 +60,18 @@
   border: none;
   border-radius: 4px;
   cursor: pointer;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  border: 0;
+  padding: 0;
+
+  white-space: nowrap;
+  clip-path: inset(100%);
+  clip: rect(0 0 0 0);
+  overflow: hidden;
 }

--- a/src/components/FlightBooking.tsx
+++ b/src/components/FlightBooking.tsx
@@ -1,70 +1,68 @@
-import { useCallback, useState } from 'react';
+import { useState } from 'react';
 
-import helpIcon from '../assets/help.svg';
-import plus from '../assets/plus.svg';
-import minus from '../assets/minus.svg';
+import './FlightBooking.css';
 
-import styles from './FlightBooking.module.css';
-
-const MIN_PASSENGERS = 1;
 const MAX_PASSENGERS = 3;
 
 const FlightBooking = () => {
-  const [adultCount, setAdultCount] = useState(MIN_PASSENGERS);
-  const [statusMessage, setStatusMessage] = useState('');
-  const [showTooltip, setShowTooltip] = useState(false);
+  const [adultCount, setAdultCount] = useState(1);
+  const [announcement, setAnnouncement] = useState('');
 
-  const incrementCount = useCallback(() => {
-    if (adultCount === MAX_PASSENGERS) {
-      setStatusMessage('최대 승객 수에 도달했습니다');
-      return;
-    }
+  const incrementCount = () => {
+    setAdultCount((prev) => {
+      if (prev === 3) {
+        setAnnouncement('최대 승객수 입니다');
+        return prev;
+      }
+      const newCount = Math.min(MAX_PASSENGERS, prev + 1);
 
-    setAdultCount((prev) => Math.min(MAX_PASSENGERS, prev + 1));
-    setStatusMessage('');
-  }, [adultCount]);
+      if (newCount === MAX_PASSENGERS) {
+        setAnnouncement('성인 승객 증가, 최대 승객 수에 도달했습니다.');
+      } else {
+        setAnnouncement('성인 승객 증가');
+      }
+      return newCount;
+    });
+  };
 
-  const decrementCount = useCallback(() => {
-    if (adultCount === MIN_PASSENGERS) {
-      setStatusMessage('최소 1명의 승객이 필요합니다');
-      return;
-    }
+  const decrementCount = () => {
+    setAdultCount((prev) => {
+      if (prev === 1) {
+        setAnnouncement('최소 승객수 입니다');
+        return prev;
+      }
 
-    setAdultCount((prev) => Math.max(MIN_PASSENGERS, prev - 1));
-    setStatusMessage('');
-  }, [adultCount]);
+      const newCount = Math.max(1, prev - 1);
+
+      if (newCount === MAX_PASSENGERS) {
+        setAnnouncement('성인 승객 감소, 최소 승객수 입니다');
+      } else {
+        setAnnouncement('성인 승객 감소');
+      }
+
+      return newCount;
+    });
+  };
 
   return (
-    <div className={styles.flightBooking}>
+    <div className="flight-booking">
+      <div aria-live="assertive" className="visually-hidden">
+        {announcement}
+      </div>
       <h2 className="heading-2-text">항공권 예매</h2>
-      <div className={styles.passengerCount}>
-        <div className={styles.passengerLabel}>
-          <span className="body-text">성인</span>
-          <div
-            className={styles.helpIconWrapper}
-            onMouseEnter={() => setShowTooltip(true)}
-            onMouseLeave={() => setShowTooltip(false)}
-          >
-            <img src={helpIcon} alt="도움말" className={styles.helpIcon} />
-            {showTooltip && <div className={styles.tooltip}>최대 3명까지 예약할 수 있습니다</div>}
-          </div>
-        </div>
-        <div className={styles.counter}>
+      <div className="passenger-count">
+        <span className="body-text">성인</span>
+        <div className="counter">
           <button className="button-text" onClick={decrementCount} aria-label="성인 승객 감소">
-            <img src={minus} alt="" />
+            -
           </button>
           <span aria-live="polite">{adultCount}</span>
           <button className="button-text" onClick={incrementCount} aria-label="성인 승객 증가">
-            <img src={plus} alt="" />
+            +
           </button>
         </div>
       </div>
-      {statusMessage && (
-        <div className="visually-hidden" role="alert">
-          {statusMessage}
-        </div>
-      )}
-      <button className={styles.searchButton}>항공편 검색</button>
+      <button className="search-button">항공편 검색</button>
     </div>
   );
 };

--- a/src/components/FlightBooking.tsx
+++ b/src/components/FlightBooking.tsx
@@ -4,45 +4,35 @@ import styles from './FlightBooking.module.css';
 import VisuallyHidden from './VisuallyHidden';
 
 const MAX_PASSENGERS = 3;
+const MIN_PASSENGERS = 1;
 
 const FlightBooking = () => {
   const [adultCount, setAdultCount] = useState(1);
   const [announcement, setAnnouncement] = useState('');
 
   const incrementCount = () => {
-    setAdultCount((prev) => {
-      if (prev === 3) {
-        setAnnouncement('최대 승객수 입니다');
-        return prev;
-      }
-      const newCount = Math.min(MAX_PASSENGERS, prev + 1);
+    if (adultCount < MAX_PASSENGERS) {
+      const newCount = adultCount + 1;
+      setAdultCount(newCount);
 
       if (newCount === MAX_PASSENGERS) {
         setAnnouncement('성인 승객 증가, 최대 승객 수에 도달했습니다.');
       } else {
         setAnnouncement('성인 승객 증가');
       }
-      return newCount;
-    });
+    } else {
+      setAnnouncement('최대 승객수 입니다');
+    }
   };
 
   const decrementCount = () => {
-    setAdultCount((prev) => {
-      if (prev === 1) {
-        setAnnouncement('최소 승객수 입니다');
-        return prev;
-      }
-
-      const newCount = Math.max(1, prev - 1);
-
-      if (newCount === MAX_PASSENGERS) {
-        setAnnouncement('성인 승객 감소, 최소 승객수 입니다');
-      } else {
-        setAnnouncement('성인 승객 감소');
-      }
-
-      return newCount;
-    });
+    if (adultCount > MIN_PASSENGERS) {
+      const newCount = adultCount - 1;
+      setAdultCount(newCount);
+      setAnnouncement('성인 승객 감소');
+    } else {
+      setAnnouncement('최소 승객수 입니다');
+    }
   };
 
   return (

--- a/src/components/FlightBooking.tsx
+++ b/src/components/FlightBooking.tsx
@@ -16,12 +16,12 @@ const FlightBooking = () => {
       setAdultCount(newCount);
 
       if (newCount === MAX_PASSENGERS) {
-        setAnnouncement('성인 승객 증가, 최대 승객 수에 도달했습니다.');
+        setAnnouncement(`성인 승객 ${newCount}명 선택되었습니다. 최대 승객 수에 도달했습니다.`);
       } else {
-        setAnnouncement('성인 승객 증가');
+        setAnnouncement(`성인 승객 ${newCount}명 선택되었습니다.`);
       }
     } else {
-      setAnnouncement('최대 승객수 입니다');
+      setAnnouncement('최대 승객 수입니다.');
     }
   };
 
@@ -29,16 +29,16 @@ const FlightBooking = () => {
     if (adultCount > MIN_PASSENGERS) {
       const newCount = adultCount - 1;
       setAdultCount(newCount);
-      setAnnouncement('성인 승객 감소');
+      setAnnouncement(`성인 승객 ${newCount}명 선택되었습니다.`);
     } else {
-      setAnnouncement('최소 승객수 입니다');
+      setAnnouncement('최소 승객 수입니다.');
     }
   };
 
   return (
     <div className={styles['flight-booking']}>
       <VisuallyHidden>
-        <div aria-live="assertive">{announcement}</div>
+        <div aria-live="polite">{announcement}</div>
       </VisuallyHidden>
       <h2 className="heading-2-text">항공권 예매</h2>
       <div className={styles['passenger-count']}>
@@ -47,7 +47,7 @@ const FlightBooking = () => {
           <button className="button-text" onClick={decrementCount} aria-label="성인 승객 감소">
             -
           </button>
-          <span aria-live="polite">{adultCount}</span>
+          <span>{adultCount}</span>
           <button className="button-text" onClick={incrementCount} aria-label="성인 승객 증가">
             +
           </button>

--- a/src/components/FlightBooking.tsx
+++ b/src/components/FlightBooking.tsx
@@ -1,69 +1,67 @@
-import { useCallback, useState } from 'react';
-
-import helpIcon from '../assets/help.svg';
-import plus from '../assets/plus.svg';
-import minus from '../assets/minus.svg';
+import { useState } from 'react';
 
 import styles from './FlightBooking.module.css';
 
-const MIN_PASSENGERS = 1;
 const MAX_PASSENGERS = 3;
 
 const FlightBooking = () => {
-  const [adultCount, setAdultCount] = useState(MIN_PASSENGERS);
-  const [statusMessage, setStatusMessage] = useState('');
-  const [showTooltip, setShowTooltip] = useState(false);
+  const [adultCount, setAdultCount] = useState(1);
+  const [announcement, setAnnouncement] = useState('');
 
-  const incrementCount = useCallback(() => {
-    if (adultCount === MAX_PASSENGERS) {
-      setStatusMessage('최대 승객 수에 도달했습니다');
-      return;
-    }
+  const incrementCount = () => {
+    setAdultCount((prev) => {
+      if (prev === 3) {
+        setAnnouncement('최대 승객수 입니다');
+        return prev;
+      }
+      const newCount = Math.min(MAX_PASSENGERS, prev + 1);
 
-    setAdultCount((prev) => Math.min(MAX_PASSENGERS, prev + 1));
-    setStatusMessage('');
-  }, [adultCount]);
+      if (newCount === MAX_PASSENGERS) {
+        setAnnouncement('성인 승객 증가, 최대 승객 수에 도달했습니다.');
+      } else {
+        setAnnouncement('성인 승객 증가');
+      }
+      return newCount;
+    });
+  };
 
-  const decrementCount = useCallback(() => {
-    if (adultCount === MIN_PASSENGERS) {
-      setStatusMessage('최소 1명의 승객이 필요합니다');
-      return;
-    }
+  const decrementCount = () => {
+    setAdultCount((prev) => {
+      if (prev === 1) {
+        setAnnouncement('최소 승객수 입니다');
+        return prev;
+      }
 
-    setAdultCount((prev) => Math.max(MIN_PASSENGERS, prev - 1));
-    setStatusMessage('');
-  }, [adultCount]);
+      const newCount = Math.max(1, prev - 1);
+
+      if (newCount === MAX_PASSENGERS) {
+        setAnnouncement('성인 승객 감소, 최소 승객수 입니다');
+      } else {
+        setAnnouncement('성인 승객 감소');
+      }
+
+      return newCount;
+    });
+  };
 
   return (
     <div className={styles.flightBooking}>
+      <div aria-live="assertive" className={styles.visuallyHidden}>
+        {announcement}
+      </div>
       <h2 className="heading-2-text">항공권 예매</h2>
       <div className={styles.passengerCount}>
-        <div className={styles.passengerLabel}>
-          <span className="body-text">성인</span>
-          <div
-            className={styles.helpIconWrapper}
-            onMouseEnter={() => setShowTooltip(true)}
-            onMouseLeave={() => setShowTooltip(false)}
-          >
-            <img src={helpIcon} alt="도움말" className={styles.helpIcon} />
-            {showTooltip && <div className={styles.tooltip}>최대 3명까지 예약할 수 있습니다</div>}
-          </div>
-        </div>
+        <span className="body-text">성인</span>
         <div className={styles.counter}>
           <button className="button-text" onClick={decrementCount} aria-label="성인 승객 감소">
-            <img src={minus} alt="" />
+            -
           </button>
           <span aria-live="polite">{adultCount}</span>
           <button className="button-text" onClick={incrementCount} aria-label="성인 승객 증가">
-            <img src={plus} alt="" />
+            +
           </button>
         </div>
       </div>
-      {statusMessage && (
-        <div className="visually-hidden" role="alert">
-          {statusMessage}
-        </div>
-      )}
       <button className={styles.searchButton}>항공편 검색</button>
     </div>
   );

--- a/src/components/FlightBooking.tsx
+++ b/src/components/FlightBooking.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 
 import styles from './FlightBooking.module.css';
+import VisuallyHidden from './VisuallyHidden';
 
 const MAX_PASSENGERS = 3;
 
@@ -46,9 +47,9 @@ const FlightBooking = () => {
 
   return (
     <div className={styles['flight-booking']}>
-      <div aria-live="assertive" className={styles['visually-hidden']}>
-        {announcement}
-      </div>
+      <VisuallyHidden>
+        <div aria-live="assertive">{announcement}</div>
+      </VisuallyHidden>
       <h2 className="heading-2-text">항공권 예매</h2>
       <div className={styles['passenger-count']}>
         <span className="body-text">성인</span>

--- a/src/components/FlightBooking.tsx
+++ b/src/components/FlightBooking.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+
 import styles from './FlightBooking.module.css';
 
 const MAX_PASSENGERS = 3;
@@ -48,23 +49,15 @@ const FlightBooking = () => {
       <div aria-live="assertive" className={styles['visually-hidden']}>
         {announcement}
       </div>
-      <h2 className={styles['heading-2-text']}>항공권 예매</h2>
+      <h2 className="heading-2-text">항공권 예매</h2>
       <div className={styles['passenger-count']}>
-        <span className={styles['body-text']}>성인</span>
-        <div className={styles['counter']}>
-          <button
-            className={styles['button-text']}
-            onClick={decrementCount}
-            aria-label="성인 승객 감소"
-          >
+        <span className="body-text">성인</span>
+        <div className={styles.counter}>
+          <button className="button-text" onClick={decrementCount} aria-label="성인 승객 감소">
             -
           </button>
           <span aria-live="polite">{adultCount}</span>
-          <button
-            className={styles['button-text']}
-            onClick={incrementCount}
-            aria-label="성인 승객 증가"
-          >
+          <button className="button-text" onClick={incrementCount} aria-label="성인 승객 증가">
             +
           </button>
         </div>

--- a/src/components/FlightBooking.tsx
+++ b/src/components/FlightBooking.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
-
-import './FlightBooking.css';
+import styles from './FlightBooking.module.css';
 
 const MAX_PASSENGERS = 3;
 
@@ -45,24 +44,32 @@ const FlightBooking = () => {
   };
 
   return (
-    <div className="flight-booking">
-      <div aria-live="assertive" className="visually-hidden">
+    <div className={styles['flight-booking']}>
+      <div aria-live="assertive" className={styles['visually-hidden']}>
         {announcement}
       </div>
-      <h2 className="heading-2-text">항공권 예매</h2>
-      <div className="passenger-count">
-        <span className="body-text">성인</span>
-        <div className="counter">
-          <button className="button-text" onClick={decrementCount} aria-label="성인 승객 감소">
+      <h2 className={styles['heading-2-text']}>항공권 예매</h2>
+      <div className={styles['passenger-count']}>
+        <span className={styles['body-text']}>성인</span>
+        <div className={styles['counter']}>
+          <button
+            className={styles['button-text']}
+            onClick={decrementCount}
+            aria-label="성인 승객 감소"
+          >
             -
           </button>
           <span aria-live="polite">{adultCount}</span>
-          <button className="button-text" onClick={incrementCount} aria-label="성인 승객 증가">
+          <button
+            className={styles['button-text']}
+            onClick={incrementCount}
+            aria-label="성인 승객 증가"
+          >
             +
           </button>
         </div>
       </div>
-      <button className="search-button">항공편 검색</button>
+      <button className={styles['search-button']}>항공편 검색</button>
     </div>
   );
 };

--- a/src/components/TravelSection.module.css
+++ b/src/components/TravelSection.module.css
@@ -86,16 +86,3 @@
   width: 24px;
   height: 24px;
 }
-
-/* 스크린 리더 전용 텍스트 */
-.srOnly {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
-}

--- a/src/components/TravelSection.module.css
+++ b/src/components/TravelSection.module.css
@@ -86,3 +86,16 @@
   width: 24px;
   height: 24px;
 }
+
+/* 스크린 리더 전용 텍스트 */
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -59,31 +59,79 @@ const TravelSection = () => {
     window.open(link, '_blank', 'noopener,noreferrer');
   };
 
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key === 'ArrowLeft') {
+      event.preventDefault();
+      prevTravel();
+    } else if (event.key === 'ArrowRight') {
+      event.preventDefault();
+      nextTravel();
+    }
+  };
+
+  const formatPrice = (price: number) => {
+    return price.toLocaleString('ko-KR');
+  };
+
   return (
-    <div className={styles.travelSection}>
-      <button className={`${styles.navButton} ${styles.navButtonPrev}`} onClick={prevTravel}>
-        <img src={chevronLeft} className={styles.navButtonIcon} />
+    <div
+      className={styles.travelSection}
+      role="region"
+      aria-label="지금 떠나기 좋은 여행 상품 캐로셀"
+      onKeyDown={handleKeyDown}
+      tabIndex={0}
+    >
+      <button
+        className={`${styles.navButton} ${styles.navButtonPrev}`}
+        onClick={prevTravel}
+        type="button"
+      >
+        <img src={chevronLeft} className={styles.navButtonIcon} alt="이전 여행 상품" />
       </button>
-      <div className={styles.carousel}>
+
+      <div className={styles.carousel} role="group" aria-live="polite">
+        <div className={styles.srOnly}>
+          {travelOptions.length}개의 여행상품중 {currentIndex + 1}번째 상품
+        </div>
         {travelOptions.map((option, index) => (
           <div
             key={index}
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
             onClick={() => handleCardClick(option.link)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                handleCardClick(option.link);
+              }
+            }}
+            role="button"
+            tabIndex={index === currentIndex ? 0 : -1}
+            aria-label={`${option.departure} 출발 ${option.destination} 도착 ${
+              option.type
+            } 가격 ${formatPrice(option.price)}원 선택하면 예약 페이지로 이동합니다`}
           >
-            <img src={option.image} className={styles.cardImage} />
+            <img
+              src={option.image}
+              className={styles.cardImage}
+              alt={`${option.departure}에서 ${option.destination}으로 가는 여행 상품 이미지`}
+            />
             <div className={styles.cardContent}>
-              <p className={`${styles.cardTitle} heading-3-text`}>
+              <h3 className={`${styles.cardTitle} heading-3-text`}>
                 {option.departure} - {option.destination}
-              </p>
+              </h3>
               <p className={`${styles.cardType} body-text`}>{option.type}</p>
-              <p className={`${styles.cardPrice} body-text`}>KRW {option.price.toLocaleString()}</p>
+              <p className={`${styles.cardPrice} body-text`}>KRW {formatPrice(option.price)}</p>
             </div>
           </div>
         ))}
       </div>
-      <button className={`${styles.navButton} ${styles.navButtonNext}`} onClick={nextTravel}>
-        <img src={chevronRight} className={styles.navButtonIcon} />
+
+      <button
+        className={`${styles.navButton} ${styles.navButtonNext}`}
+        onClick={nextTravel}
+        type="button"
+      >
+        <img src={chevronRight} className={styles.navButtonIcon} alt="다음 여행 상품" />
       </button>
     </div>
   );

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -95,7 +95,7 @@ const TravelSection = () => {
           {travelOptions.length}개의 여행상품중 {currentIndex + 1}번째 상품
         </VisuallyHidden>
         {travelOptions.map((option, index) => (
-          <div
+          <a
             key={index}
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
             onClick={() => handleCardClick(option.link)}
@@ -123,7 +123,7 @@ const TravelSection = () => {
               <p className={`${styles.cardType} body-text`}>{option.type}</p>
               <p className={`${styles.cardPrice} body-text`}>KRW {formatPrice(option.price)}</p>
             </div>
-          </div>
+          </a>
         ))}
       </div>
 

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -114,7 +114,7 @@ const TravelSection = () => {
             <img
               src={option.image}
               className={styles.cardImage}
-              alt={`${option.departure}에서 ${option.destination}으로 가는 여행 상품 이미지`}
+              alt=""
             />
             <div className={styles.cardContent}>
               <h3 className={`${styles.cardTitle} heading-3-text`}>

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -7,6 +7,7 @@ import chevronLeft from '../assets/chevron-left.svg';
 import chevronRight from '../assets/chevron-right.svg';
 
 import styles from './TravelSection.module.css';
+import VisuallyHidden from './VisuallyHidden';
 
 interface TravelOption {
   departure: string;
@@ -90,9 +91,9 @@ const TravelSection = () => {
       </button>
 
       <div className={styles.carousel} role="group" aria-live="polite">
-        <div className={styles.srOnly}>
+        <VisuallyHidden>
           {travelOptions.length}개의 여행상품중 {currentIndex + 1}번째 상품
-        </div>
+        </VisuallyHidden>
         {travelOptions.map((option, index) => (
           <div
             key={index}

--- a/src/components/VisuallyHidden.module.css
+++ b/src/components/VisuallyHidden.module.css
@@ -1,10 +1,11 @@
-.visually-hidden {
+.visuallyHidden {
   position: absolute;
   width: 1px;
   height: 1px;
   padding: 0;
   margin: -1px;
   overflow: hidden;
+  clip-path: inset(100%);
   clip: rect(0, 0, 0, 0);
   white-space: nowrap;
   border: 0;

--- a/src/components/VisuallyHidden.tsx
+++ b/src/components/VisuallyHidden.tsx
@@ -1,0 +1,13 @@
+import { ReactNode } from 'react';
+import styles from './VisuallyHidden.module.css';
+
+interface VisuallyHiddenProps {
+  children: ReactNode;
+  className?: string;
+}
+
+const VisuallyHidden = ({ children, className = '' }: VisuallyHiddenProps) => {
+  return <span className={`${styles.visuallyHidden} ${className}`}>{children}</span>;
+};
+
+export default VisuallyHidden;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,7 +2,6 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 
 import './Typography.css';
-import './Accessibility.css';
 import './index.css';
 
 import App from './App.tsx';


### PR DESCRIPTION
## 🔥 결과

<!-- 개선 작업 후 모바일 낭독기를 사용해서 미션 페이지를 읽어보세요 -->

- 배포한 페이지 접근 경로(GitHub Pages): https://daeun-100.github.io/a11y-airline/
- 스크린 리더 화면 녹화 영상 (before / after) 

after
https://github.com/user-attachments/assets/0e2165ed-4d6a-4281-9952-00c715ec5687


## ✅ 개선 작업 목록

<!-- 각 요구 사항을 위해 어떤 부분을 고민/학습해보았고, 결과적으로 어떤 개선 작업을 진행했는지 적어주세요-->

**1 컴포넌트 접근성 개선 - 이미지 캐로셀**

- [x] 스크린 리더가 캐로셀의 전체 아이템 수를 읽을 수 있어야 합니다.
- 전체 캐로셀 아이템중 몇번째인지를 명시
- srOnly 클래스로 시각적으로는 숨기되 스크린 리더로는 읽을 수 있도록 구현
- aria-live="polite"로 캐로셀 변경 시 자동으로 읽어주도록 설정
- [x] 스크린 리더가 이미지 캐로셀 내 각 아이템 정보를 읽을 수 있어야 합니다.
  - [x] 여행지, 좌석 유형, 가격 정보를 한번에 읽을 수 있어야 합니다.
  - aria-label을 사용하여 모든 중요한 정보를 하나의 속성으로 제공
  - [x] 이전/다음 아이템으로 이동하고 현재 보이는 아이템의 정보를 읽을 수 있어야 합니다.
  -  버튼에 명확한 alt 텍스트 제공
  - aria-live="polite"로 아이템 변경 시 자동으로 새 정보 읽어주기
- [x] 각 아이템을 선택하면 각각에 맞는 링크로 이동할 수 있어야 합니다.

**2 페이지 접근성 개선**

- [x] 페이지를 하나의 문서로 읽을 수 있어야 합니다.
  - [x] 페이지에 적절한 제목(title)을 제공하세요. 제목은 페이지의 주요 내용을 간결하게 설명해야 합니다.
  - [x] 페이지의 주요 영역을 시맨틱 태그를 사용해 명확히 구분해 주세요
  - [x] 헤딩을 논리적인 순서로 사용해 페이지 구조를 명확히 해주세요
- [x] 키보드 사용자를 위해 페이지 최상단에 '본문으로 바로가기' 링크를 제공해 반복되는 메뉴를 건너뛸 수 있게 해주세요

## 🧐 우리 팀의 접근성 체크리스트

<!--
우리 서비스에서 이런 부분의 접근성은 챙겨봐야겠다! 하는 체크리스트 v1을 만들고, 리뷰어와 의견을 나눠보세요
- 우리 팀 서비스에서 가장 중요하고 자주 사용되는 기능 플로우 1개를 선택하고 간단히 나열해 주세요 (예: 로그인 → 상품 검색 → 상품 선택 → 장바구니 추가 → 결제)

홈 → 방 생성/참가 → 닉네임 입력 → 메뉴 선택 → 로비 → 미니게임 플레이 → 룰렛 → 결과 확인
 
- 해당 플로우의 각 단계에 대해 다음 질문을 생각해 보세요.
  - 1. 화면을 볼 수 없는 사용자가 이 단계를 완료할 수 있는가?
  - 2. 이 단계에서 제공하는 정보나 지시 사항이 모든 사용자에게 명확한가?
- 질문에 대해 팀원들과 의견을 나눠본 것을 바탕으로, 우리 팀만의 접근성 체크리스트 v1을 만들고 리뷰어와 의견을 나눠보세요. (예: "모든 이미지에 적절한 대체 텍스트가 제공되는가?")
-->

### 주요 기능 플로우
**커피빵 플로우**: 홈 → 방 생성/참가 → 닉네임 입력 → 메뉴 선택 → 로비 → 미니게임 플레이 → 룰렛 → 결과 확인

#### **1단계: 홈 화면**
- [ ] **화면을 볼 수 없는 사용자가 방 만들기/참가하기를 구분할 수 있는가?**
- [ ] **초기 방문자를 위한 스플래시 화면이 스크린 리더 사용자에게 적절한가?**
#### **2단계: 닉네임 입력**
- [ ] **입력 오류 시 명확한 오류 메시지가 제공되는가?**
#### **3단계: 메뉴 선택**
- [ ] **메뉴 이미지만으로 선택할 수 있는가?**
- [ ] **커스텀 메뉴 입력 시 필수 정보가 명확한가?**
#### **4단계: 로비 (게임 준비)**
- [ ] **참가자, 룰렛, 미니게임 탭 간 전환이 키보드로 가능한가?**
- [ ] **각 참가자의 준비 상태를 스크린 리더가 알 수 있는가?**
- [ ] **호스트/게스트 역할에 따른 버튼 차이가 명확한가?**
#### **5단계: 미니게임 플레이**
- [ ] **카드 선택 게임에서 카드가 스크린 리더로 구분 가능한가?**
- [ ] **게임 진행 상황과 타이머 정보가 접근 가능한가?**
- [ ] **게임 결과를 텍스트로 확인할 수 있는가?**
#### **6단계: 룰렛**
- [ ] **각 참가자의 확률 정보가 접근 가능한가?**
- [ ] **당첨자 발표를 스크린 리더가 인식할 수 있는가?**
#### **7단계: 결과 확인**
- [ ] **최종 결과와 주문 리스트가 스크린 리더로 읽을 수 있는가?**
- [ ] **게임 종료 후 다음 액션(새 게임, 방 나가기 등)이 명확한가?**

