### PR TITLE
[항공사 웹사이트의 컴포넌트 접근성 높이기] 오거스(오명석) 미션 제출합니다

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Ohgus's A11y Airline</title>
+    <title>A11y Airline</title>
   </head>
 
   <body>

--- a/index.html
+++ b/index.html
@@ -1,15 +1,13 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Ohgus's A11y Airline</title>
+  </head>
 
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>React App</title>
-</head>
-
-<body>
-  <div id="root"></div>
-  <script type="module" src="/src/main.tsx"></script>
-</body>
-
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "deploy": "npm run build && npx gh-pages -d dist"
   },
   "author": "woowacourse",
-  "homepage": "https://{username}.github.io/a11y-airline",
+  "homepage": "https://ohgus.github.io/a11y-airline",
   "license": "MIT",
   "dependencies": {
     "react": "^18.3.1",

--- a/src/App.module.css
+++ b/src/App.module.css
@@ -40,3 +40,22 @@
   background-color: white;
   text-align: center;
 }
+
+.skipNav {
+  position: relative;
+}
+
+.skipLink {
+  position: absolute;
+  left: -9999px;
+  top: 0;
+  background-color: #fff;
+  padding: 10px;
+  border: 1px solid #000;
+  color: #000;
+  z-index: 1000;
+  text-decoration: none;
+  &:focus {
+    left: 0;
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,11 +25,11 @@ function App() {
           A11Y AIRLINE은 고객 여러분의 안전하고 쾌적한 여행을 위해 최선을 다하고 있습니다.
         </p>
       </header>
-      <main id="main-content" className={styles.main}>
-        <section id="flightBooking" className={styles.flightBooking}>
+      <main id="main-content" className={styles.main} tabIndex={-1}>
+        <section id="flightBooking" className={styles.flightBooking} tabIndex={0}>
           <FlightBooking />
         </section>
-        <section id="travelSection" className={styles.travelSection}>
+        <section id="travelSection" className={styles.travelSection} tabIndex={1}>
           <h2 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h2>
           <TravelSection />
         </section>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,17 @@ import TravelSection from './components/TravelSection';
 function App() {
   return (
     <div className={styles.app}>
+      <nav className={styles.skipNav}>
+        <a href="#main-content" className={styles.skipLink}>
+          본문으로 바로가기
+        </a>
+        <a href="#flightBooking" className={styles.skipLink}>
+          항공권 예매로 바로가기
+        </a>
+        <a href="#travelSection" className={styles.skipLink}>
+          지금 떠나기 좋은 여행으로 바로가기
+        </a>
+      </nav>
       <Navigation />
       <header className={styles.header}>
         <h1 className={`${styles.title} heading-1-text`}>A11Y AIRLINE</h1>
@@ -15,10 +26,10 @@ function App() {
         </p>
       </header>
       <main id="main-content" className={styles.main}>
-        <section className={styles.flightBooking}>
+        <section id="flightBooking" className={styles.flightBooking}>
           <FlightBooking />
         </section>
-        <section className={styles.travelSection}>
+        <section id="travelSection" className={styles.travelSection}>
           <h2 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h2>
           <TravelSection />
         </section>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,24 +8,24 @@ function App() {
   return (
     <div className={styles.app}>
       <Navigation />
-      <div className={styles.header}>
+      <header className={styles.header}>
         <h1 className={`${styles.title} heading-1-text`}>A11Y AIRLINE</h1>
         <p className="body-text">
           A11Y AIRLINE은 고객 여러분의 안전하고 쾌적한 여행을 위해 최선을 다하고 있습니다.
         </p>
-      </div>
-      <div id="main-content" className={styles.main}>
-        <div className={styles.flightBooking}>
+      </header>
+      <main id="main-content" className={styles.main}>
+        <section className={styles.flightBooking}>
           <FlightBooking />
-        </div>
-        <div className={styles.travelSection}>
+        </section>
+        <section className={styles.travelSection}>
           <h1 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h1>
           <TravelSection />
-        </div>
-      </div>
-      <div className={styles.footer}>
+        </section>
+      </main>
+      <footer className={styles.footer}>
         <p className="body-text">&copy; A11Y AIRLINE</p>
-      </div>
+      </footer>
       {/* 추가 CHALLENGE: 모달 포커스 트랩 */}
       {/* <PromotionModal /> */}
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,7 @@ function App() {
           <FlightBooking />
         </section>
         <section className={styles.travelSection}>
-          <h1 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h1>
+          <h2 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h2>
           <TravelSection />
         </section>
       </main>

--- a/src/components/FlightBooking.tsx
+++ b/src/components/FlightBooking.tsx
@@ -36,7 +36,7 @@ const FlightBooking = () => {
 
   return (
     <div className={styles.flightBooking}>
-      <h2 className="heading-2-text">항공권 예매</h2>
+      <h3 className="heading-3-text">항공권 예매</h3>
       <div className={styles.passengerCount}>
         <div className={styles.passengerLabel}>
           <span className="body-text">성인</span>

--- a/src/components/FlightBooking.tsx
+++ b/src/components/FlightBooking.tsx
@@ -36,7 +36,7 @@ const FlightBooking = () => {
 
   return (
     <div className={styles.flightBooking}>
-      <h3 className="heading-3-text">항공권 예매</h3>
+      <h2 className="heading-2-text">항공권 예매</h2>
       <div className={styles.passengerCount}>
         <div className={styles.passengerLabel}>
           <span className="body-text">성인</span>

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -55,37 +55,59 @@ const TravelSection = () => {
     setCurrentIndex((prevIndex) => (prevIndex - 1 + travelOptions.length) % travelOptions.length);
   };
 
-  const handleCardClick = (link: string) => {
-    window.open(link, '_blank', 'noopener,noreferrer');
-  };
-
   return (
-    <div className={styles.travelSection}>
-      <button className={`${styles.navButton} ${styles.navButtonPrev}`} onClick={prevTravel}>
+    <section className={styles.travelSection}>
+      <span className="visually-hidden" role="status">
+        {`총 ${travelOptions.length}개 상품 중 ${currentIndex + 1}번째`}
+      </span>
+      <button
+        className={`${styles.navButton} ${styles.navButtonPrev}`}
+        onClick={prevTravel}
+        aria-label="이전 여행 상품 보기"
+      >
         <img src={chevronLeft} className={styles.navButtonIcon} />
       </button>
-      <div className={styles.carousel}>
+      <ul className={styles.carousel} aria-live="polite">
         {travelOptions.map((option, index) => (
-          <div
+          <li
+            aria-hidden={index !== currentIndex}
             key={index}
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
-            onClick={() => handleCardClick(option.link)}
           >
-            <img src={option.image} className={styles.cardImage} />
-            <div className={styles.cardContent}>
-              <p className={`${styles.cardTitle} heading-3-text`}>
-                {option.departure} - {option.destination}
-              </p>
-              <p className={`${styles.cardType} body-text`}>{option.type}</p>
-              <p className={`${styles.cardPrice} body-text`}>KRW {option.price.toLocaleString()}</p>
-            </div>
-          </div>
+            <a
+              href={option.link}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label={`${option.departure}에서 ${option.destination}으로 이동, ${
+                option.type
+              }, ${option.price.toLocaleString()}원. 선택하시면 상세 페이지로 이동합니다.`}
+            >
+              <img
+                src={option.image}
+                className={styles.cardImage}
+                alt={`${option.departure}에서 ${option.destination}까지`}
+              />
+              <div className={styles.cardContent} aria-hidden="true">
+                <p className={`${styles.cardTitle} heading-3-text`}>
+                  {option.departure} - {option.destination}
+                </p>
+                <p className={`${styles.cardType} body-text`}>{option.type}</p>
+                <p className={`${styles.cardPrice} body-text`}>
+                  KRW {option.price.toLocaleString()}
+                </p>
+              </div>
+            </a>
+          </li>
         ))}
-      </div>
-      <button className={`${styles.navButton} ${styles.navButtonNext}`} onClick={nextTravel}>
+      </ul>
+      <button
+        className={`${styles.navButton} ${styles.navButtonNext}`}
+        onClick={nextTravel}
+        aria-label="다음 여행 상품 보기"
+      >
         <img src={chevronRight} className={styles.navButtonIcon} />
       </button>
-    </div>
+    </section>
   );
 };
 

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -65,7 +65,7 @@ const TravelSection = () => {
         onClick={prevTravel}
         aria-label="이전 여행 상품 보기"
       >
-        <img src={chevronLeft} className={styles.navButtonIcon} />
+        <img src={chevronLeft} className={styles.navButtonIcon} alt="이전 여행 상품 보기" />
       </button>
       <ul className={styles.carousel} aria-live="polite">
         {travelOptions.map((option, index) => (
@@ -105,7 +105,7 @@ const TravelSection = () => {
         onClick={nextTravel}
         aria-label="다음 여행 상품 보기"
       >
-        <img src={chevronRight} className={styles.navButtonIcon} />
+        <img src={chevronRight} className={styles.navButtonIcon} alt="다음 여행 상품 보기" />
       </button>
     </section>
   );

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -56,7 +56,7 @@ const TravelSection = () => {
   };
 
   return (
-    <section className={styles.travelSection}>
+    <div className={styles.travelSection}>
       <span className="visually-hidden" role="status">
         {`총 ${travelOptions.length}개 상품 중 ${currentIndex + 1}번째`}
       </span>
@@ -107,7 +107,7 @@ const TravelSection = () => {
       >
         <img src={chevronRight} className={styles.navButtonIcon} alt="다음 여행 상품 보기" />
       </button>
-    </section>
+    </div>
   );
 };
 

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -60,13 +60,6 @@ const TravelSection = () => {
       <span className="visually-hidden" role="status">
         {`총 ${travelOptions.length}개 상품 중 ${currentIndex + 1}번째`}
       </span>
-      <button
-        className={`${styles.navButton} ${styles.navButtonPrev}`}
-        onClick={prevTravel}
-        aria-label="이전 여행 상품 보기"
-      >
-        <img src={chevronLeft} className={styles.navButtonIcon} alt="이전 여행 상품 보기" />
-      </button>
       <ul className={styles.carousel} aria-live="polite">
         {travelOptions.map((option, index) => (
           <li
@@ -100,6 +93,13 @@ const TravelSection = () => {
           </li>
         ))}
       </ul>
+      <button
+        className={`${styles.navButton} ${styles.navButtonPrev}`}
+        onClick={prevTravel}
+        aria-label="이전 여행 상품 보기"
+      >
+        <img src={chevronLeft} className={styles.navButtonIcon} alt="이전 여행 상품 보기" />
+      </button>
       <button
         className={`${styles.navButton} ${styles.navButtonNext}`}
         onClick={nextTravel}

--- a/src/index.css
+++ b/src/index.css
@@ -117,3 +117,16 @@ body {
   font-family: Arial, sans-serif;
   background-color: #f5f5f5;
 }
+
+a:link,
+a:visited {
+  text-decoration: none;
+  color: inherit;
+}
+
+a:focus,
+a:hover,
+a:active {
+  text-decoration: none;
+  color: inherit;
+}


### PR DESCRIPTION
안녕하세요 데이지 🌸 오거스 입니다 🤣
미션으로는 처음 뵙네요 잘부탁드립니다 😁

화면 녹화의 경우 음성 녹화가 제대로 안되어서 첨부하지 못했습니다... 양해 부탁드립니다 🙇
대신 lighthouse 전후 측정 스크린샷을 첨부했습니다.

이번 미션을 진행하면서 처음으로 접근성이라는 영역에 대해서 생각해본 것 같은데요, 그래서 처음에는 조금 막막한 부분도 있었지만 하나씩 개선해가면서 처음 공부한 부분들이 많아서 재밌게 진행할 수 있었습니다!

데이지는 원래도 접근성 같은 부분을 고려하면서 개발을 하셨는지 궁금하네요 🤔

## 🔥 결과

<!-- 개선 작업 후 모바일 낭독기를 사용해서 미션 페이지를 읽어보세요 -->

- 배포한 페이지 접근 경로(GitHub Pages):[배포링크](https://ohgus.github.io/a11y-airline/)
- 스크린 리더 화면 녹화 영상 (before / after)

<img width="930" height="531" alt="image" src="https://github.com/user-attachments/assets/78194349-2e96-4fdc-8762-acf5bc76c38a" />


## ✅ 개선 작업 목록

<!-- 각 요구 사항을 위해 어떤 부분을 고민/학습해보았고, 결과적으로 어떤 개선 작업을 진행했는지 적어주세요-->

**1 컴포넌트 접근성 개선 - 이미지 캐로셀**

- [x] 스크린 리더가 캐로셀의 전체 아이템 수를 읽을 수 있어야 합니다.
- [x] 스크린 리더가 이미지 캐로셀 내 각 아이템 정보를 읽을 수 있어야 합니다.
  - [x] 여행지, 좌석 유형, 가격 정보를 한번에 읽을 수 있어야 합니다.
  - [x] 이전/다음 아이템으로 이동하고 현재 보이는 아이템의 정보를 읽을 수 있어야 합니다.
- [x] 각 아이템을 선택하면 각각에 맞는 링크로 이동할 수 있어야 합니다.

**2 페이지 접근성 개선**

- [x] 페이지를 하나의 문서로 읽을 수 있어야 합니다.
  - [x] 페이지에 적절한 제목(title)을 제공하세요. 제목은 페이지의 주요 내용을 간결하게 설명해야 합니다.
  - [x] 페이지의 주요 영역을 시맨틱 태그를 사용해 명확히 구분해 주세요
  - [x] 헤딩을 논리적인 순서로 사용해 페이지 구조를 명확히 해주세요
- [x] 키보드 사용자를 위해 페이지 최상단에 '본문으로 바로가기' 링크를 제공해 반복되는 메뉴를 건너뛸 수 있게 해주세요

## 🧐 우리 팀의 접근성 체크리스트

<!--
우리 서비스에서 이런 부분의 접근성은 챙겨봐야겠다! 하는 체크리스트 v1을 만들고, 리뷰어와 의견을 나눠보세요
- 우리 팀 서비스에서 가장 중요하고 자주 사용되는 기능 플로우 1개를 선택하고 간단히 나열해 주세요 (예: 로그인 → 상품 검색 → 상품 선택 → 장바구니 추가 → 결제)
- 해당 플로우의 각 단계에 대해 다음 질문을 생각해 보세요.
  - 1. 화면을 볼 수 없는 사용자가 이 단계를 완료할 수 있는가?
  - 2. 이 단계에서 제공하는 정보나 지시 사항이 모든 사용자에게 명확한가?
- 질문에 대해 팀원들과 의견을 나눠본 것을 바탕으로, 우리 팀만의 접근성 체크리스트 v1을 만들고 리뷰어와 의견을 나눠보세요. (예: "모든 이미지에 적절한 대체 텍스트가 제공되는가?")
-->

저희 서비스 같은 경우 시각 자료를 위한 서비스가 메인인 서비스인데요, 그래서 이런 경우에는 시각장애인 분들을 위한 접근성 개선을 어떻게 해야할지 좀처럼 떠오르지 않았습니다... 🥲
그래서 만약 데이지라면 어떤 시도를 하실지 궁금합니다 ㅎ
