### PR TITLE
[항공사 웹사이트의 컴포넌트 접근성 높이기] 블루(이한희) 미션 제출합니다 

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,15 +1,13 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>A11Y AIRLINE - 항공권 예매 및 여행지 추천</title>
+  </head>
 
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>React App</title>
-</head>
-
-<body>
-  <div id="root"></div>
-  <script type="module" src="/src/main.tsx"></script>
-</body>
-
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "deploy": "npm run build && npx gh-pages -d dist"
   },
   "author": "woowacourse",
-  "homepage": "https://{username}.github.io/a11y-airline",
+  "homepage": "https://hanheel.github.io/a11y-airline",
   "license": "MIT",
   "dependencies": {
     "react": "^18.3.1",

--- a/src/App.module.css
+++ b/src/App.module.css
@@ -40,3 +40,29 @@
   background-color: white;
   text-align: center;
 }
+
+.skipLink {
+  position: absolute;
+  top: -40px;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.skipLink:focus {
+  top: 0;
+  left: 0;
+  width: auto;
+  height: auto;
+  clip: auto;
+  overflow: visible;
+  padding: 8px 16px;
+  background: #000;
+  color: #fff;
+  z-index: 100;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,7 @@ function App() {
           <FlightBooking />
         </div>
         <div className={styles.travelSection}>
-          <h1 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h1>
+          <h2 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h2>
           <TravelSection />
         </div>
       </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,24 +8,24 @@ function App() {
   return (
     <div className={styles.app}>
       <Navigation />
-      <div className={styles.header}>
+      <header className={styles.header}>
         <h1 className={`${styles.title} heading-1-text`}>A11Y AIRLINE</h1>
         <p className="body-text">
           A11Y AIRLINE은 고객 여러분의 안전하고 쾌적한 여행을 위해 최선을 다하고 있습니다.
         </p>
-      </div>
-      <div id="main-content" className={styles.main}>
+      </header>
+      <main id="main-content" className={styles.main}>
         <div className={styles.flightBooking}>
           <FlightBooking />
         </div>
-        <div className={styles.travelSection}>
+        <section className={styles.travelSection}>
           <h2 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h2>
           <TravelSection />
-        </div>
-      </div>
-      <div className={styles.footer}>
+        </section>
+      </main>
+      <footer className={styles.footer}>
         <p className="body-text">&copy; A11Y AIRLINE</p>
-      </div>
+      </footer>
       {/* 추가 CHALLENGE: 모달 포커스 트랩 */}
       {/* <PromotionModal /> */}
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,9 @@ import TravelSection from './components/TravelSection';
 function App() {
   return (
     <div className={styles.app}>
+      <a href="#main-content" className={styles.skipLink}>
+        본문으로 바로가기
+      </a>
       <Navigation />
       <header className={styles.header}>
         <h1 className={`${styles.title} heading-1-text`}>A11Y AIRLINE</h1>

--- a/src/components/TravelSection.module.css
+++ b/src/components/TravelSection.module.css
@@ -20,7 +20,9 @@
 }
 
 .cardActive {
-  display: block;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
 }
 
 .cardImage {

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -62,14 +62,21 @@ const TravelSection = () => {
 
   return (
     <div className={styles.travelSection}>
-      <div className="visually-hidden">{`${travelOptions.length}개의 상품 중 ${currentIndex}번째 상품`}</div>
-      <button className={`${styles.navButton} ${styles.navButtonPrev}`} onClick={prevTravel}>
+      <div className="visually-hidden">{`${travelOptions.length}개의 여행 상품 중 ${currentIndex}번째 상품`}</div>
+      <button
+        type="button"
+        aria-label="이전 여행 상품"
+        className={`${styles.navButton} ${styles.navButtonPrev}`}
+        onClick={prevTravel}
+      >
         <img src={chevronLeft} className={styles.navButtonIcon} />
       </button>
       <div className={styles.carousel}>
         {travelOptions.map((option, index) => (
-          <div
-            key={index}
+          <button
+            type="button"
+            aria-label="선택하면 예약 페이지로 이동합니다"
+            key={option.link}
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
             onClick={() => handleCardClick(option.link)}
           >
@@ -81,10 +88,15 @@ const TravelSection = () => {
               <p className={`${styles.cardType} body-text`}>{option.type}</p>
               <p className={`${styles.cardPrice} body-text`}>KRW {option.price.toLocaleString()}</p>
             </div>
-          </div>
+          </button>
         ))}
       </div>
-      <button className={`${styles.navButton} ${styles.navButtonNext}`} onClick={nextTravel}>
+      <button
+        type="button"
+        aria-label="다음 여행 상품"
+        className={`${styles.navButton} ${styles.navButtonNext}`}
+        onClick={nextTravel}
+      >
         <img src={chevronRight} className={styles.navButtonIcon} />
       </button>
     </div>

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -46,12 +46,15 @@ const travelOptions: TravelOption[] = [
 
 const TravelSection = () => {
   const [currentIndex, setCurrentIndex] = useState(0);
+  const [hasInteracted, setHasInteracted] = useState(false);
 
   const nextTravel = () => {
+    setHasInteracted(true);
     setCurrentIndex((prevIndex) => (prevIndex + 1) % travelOptions.length);
   };
 
   const prevTravel = () => {
+    setHasInteracted(true);
     setCurrentIndex((prevIndex) => (prevIndex - 1 + travelOptions.length) % travelOptions.length);
   };
 
@@ -67,7 +70,7 @@ const TravelSection = () => {
             key={option.link}
             aria-hidden={index !== currentIndex}
             aria-roledescription="slide"
-            aria-live="polite"
+            aria-live={hasInteracted ? 'polite' : 'off'}
           >
             <div key={option.link} className="visually-hidden">{`${
               travelOptions.length

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -60,7 +60,7 @@ const TravelSection = () => {
   };
 
   return (
-    <section className={styles.travelSection} aria-roledescription="carousel">
+    <div className={styles.travelSection}>
       <ul className={styles.carousel} id="carousel-items">
         {travelOptions.map((option, index) => (
           <li
@@ -130,7 +130,7 @@ const TravelSection = () => {
       >
         <img src={chevronRight} className={styles.navButtonIcon} alt="" />
       </button>
-    </section>
+    </div>
   );
 };
 

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -60,54 +60,64 @@ const TravelSection = () => {
   };
 
   return (
-    <div className={styles.travelSection}>
-      <div className="visually-hidden">{`${travelOptions.length}개의 여행 상품 중 ${currentIndex}번째 상품`}</div>
-      <div className={styles.carousel}>
+    <section className={styles.travelSection} aria-roledescription="carousel">
+      <ul className={styles.carousel}>
         {travelOptions.map((option, index) => (
-          <button
-            type="button"
-            aria-labelledby="card-title card-type card-price"
-            aria-describedby="button-action"
+          <li
             key={option.link}
-            className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
-            onClick={() => handleCardClick(option.link)}
             aria-hidden={index !== currentIndex}
+            aria-roledescription="slide"
+            aria-live="polite"
           >
-            <img src={option.image} className={styles.cardImage} alt="" />
-            <div className={styles.cardContent}>
-              <p
-                id="card-title"
-                aria-label={`${option.departure}출발 - ${option.destination}도착,`}
-                className={`${styles.cardTitle} heading-3-text`}
-              >
-                {option.departure} - {option.destination}
-              </p>
-              <p
-                id="card-type"
-                aria-label={`${option.type},`}
-                className={`${styles.cardType} body-text`}
-              >
-                {option.type}
-              </p>
-              <p
-                id="card-price"
-                aria-label={`가격 ${option.price.toLocaleString()}원,`}
-                className={`${styles.cardPrice} body-text`}
-              >
-                KRW {option.price.toLocaleString()}
-              </p>
-              <p id="button-action" className="visually-hidden">
-                선택하면 예약 페이지로 이동합니다
-              </p>
-            </div>
-          </button>
+            <div key={option.link} className="visually-hidden">{`${
+              travelOptions.length
+            }개의 여행 상품 중 ${currentIndex + 1}번째 상품`}</div>
+            <button
+              type="button"
+              aria-labelledby={`card-title-${index} card-type-${index} card-price-${index}`}
+              aria-describedby="button-action"
+              key={option.link}
+              className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
+              onClick={() => handleCardClick(option.link)}
+              aria-hidden={index !== currentIndex}
+            >
+              <img src={option.image} className={styles.cardImage} alt="" />
+              <div className={styles.cardContent}>
+                <p
+                  id={`card-title-${index}`}
+                  aria-label={`${option.departure}출발 - ${option.destination}도착,`}
+                  className={`${styles.cardTitle} heading-3-text`}
+                >
+                  {option.departure} - {option.destination}
+                </p>
+                <p
+                  id={`card-type-${index}`}
+                  aria-label={`${option.type},`}
+                  className={`${styles.cardType} body-text`}
+                >
+                  {option.type}
+                </p>
+                <p
+                  id={`card-price-${index}`}
+                  aria-label={`가격 ${option.price.toLocaleString()}원,`}
+                  className={`${styles.cardPrice} body-text`}
+                >
+                  KRW {option.price.toLocaleString()}
+                </p>
+                <p id="button-action" className="visually-hidden">
+                  선택하면 예약 페이지로 이동합니다
+                </p>
+              </div>
+            </button>
+          </li>
         ))}
-      </div>
+      </ul>
       <button
         type="button"
         aria-label="이전 여행 상품"
         className={`${styles.navButton} ${styles.navButtonPrev}`}
         onClick={prevTravel}
+        aria-controls="carousel-items"
       >
         <img src={chevronLeft} className={styles.navButtonIcon} alt="" />
       </button>
@@ -116,10 +126,11 @@ const TravelSection = () => {
         aria-label="다음 여행 상품"
         className={`${styles.navButton} ${styles.navButtonNext}`}
         onClick={nextTravel}
+        aria-controls="carousel-items"
       >
         <img src={chevronRight} className={styles.navButtonIcon} alt="" />
       </button>
-    </div>
+    </section>
   );
 };
 

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -71,6 +71,7 @@ const TravelSection = () => {
             key={option.link}
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
             onClick={() => handleCardClick(option.link)}
+            aria-hidden={index !== currentIndex}
           >
             <img src={option.image} className={styles.cardImage} alt="" />
             <div className={styles.cardContent}>

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -7,7 +7,6 @@ import chevronLeft from '../assets/chevron-left.svg';
 import chevronRight from '../assets/chevron-right.svg';
 
 import styles from './TravelSection.module.css';
-import '../Accessibility.css';
 
 interface TravelOption {
   departure: string;
@@ -67,18 +66,38 @@ const TravelSection = () => {
         {travelOptions.map((option, index) => (
           <button
             type="button"
-            aria-label="선택하면 예약 페이지로 이동합니다"
+            aria-labelledby="card-title card-type card-price"
+            aria-describedby="button-action"
             key={option.link}
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
             onClick={() => handleCardClick(option.link)}
           >
             <img src={option.image} className={styles.cardImage} alt="" />
             <div className={styles.cardContent}>
-              <p className={`${styles.cardTitle} heading-3-text`}>
+              <p
+                id="card-title"
+                aria-label={`${option.departure}출발 - ${option.destination}도착,`}
+                className={`${styles.cardTitle} heading-3-text`}
+              >
                 {option.departure} - {option.destination}
               </p>
-              <p className={`${styles.cardType} body-text`}>{option.type}</p>
-              <p className={`${styles.cardPrice} body-text`}>KRW {option.price.toLocaleString()}</p>
+              <p
+                id="card-type"
+                aria-label={`${option.type},`}
+                className={`${styles.cardType} body-text`}
+              >
+                {option.type}
+              </p>
+              <p
+                id="card-price"
+                aria-label={`가격 ${option.price.toLocaleString()}원,`}
+                className={`${styles.cardPrice} body-text`}
+              >
+                KRW {option.price.toLocaleString()}
+              </p>
+              <p id="button-action" className="visually-hidden">
+                선택하면 예약 페이지로 이동합니다
+              </p>
             </div>
           </button>
         ))}

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -7,6 +7,7 @@ import chevronLeft from '../assets/chevron-left.svg';
 import chevronRight from '../assets/chevron-right.svg';
 
 import styles from './TravelSection.module.css';
+import '../Accessibility.css';
 
 interface TravelOption {
   departure: string;
@@ -61,6 +62,7 @@ const TravelSection = () => {
 
   return (
     <div className={styles.travelSection}>
+      <div className="visually-hidden">{`${travelOptions.length}개의 상품 중 ${currentIndex}번째 상품`}</div>
       <button className={`${styles.navButton} ${styles.navButtonPrev}`} onClick={prevTravel}>
         <img src={chevronLeft} className={styles.navButtonIcon} />
       </button>

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -63,14 +63,6 @@ const TravelSection = () => {
   return (
     <div className={styles.travelSection}>
       <div className="visually-hidden">{`${travelOptions.length}개의 여행 상품 중 ${currentIndex}번째 상품`}</div>
-      <button
-        type="button"
-        aria-label="이전 여행 상품"
-        className={`${styles.navButton} ${styles.navButtonPrev}`}
-        onClick={prevTravel}
-      >
-        <img src={chevronLeft} className={styles.navButtonIcon} />
-      </button>
       <div className={styles.carousel}>
         {travelOptions.map((option, index) => (
           <button
@@ -80,7 +72,7 @@ const TravelSection = () => {
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
             onClick={() => handleCardClick(option.link)}
           >
-            <img src={option.image} className={styles.cardImage} />
+            <img src={option.image} className={styles.cardImage} alt="" />
             <div className={styles.cardContent}>
               <p className={`${styles.cardTitle} heading-3-text`}>
                 {option.departure} - {option.destination}
@@ -93,11 +85,19 @@ const TravelSection = () => {
       </div>
       <button
         type="button"
+        aria-label="이전 여행 상품"
+        className={`${styles.navButton} ${styles.navButtonPrev}`}
+        onClick={prevTravel}
+      >
+        <img src={chevronLeft} className={styles.navButtonIcon} alt="" />
+      </button>
+      <button
+        type="button"
         aria-label="다음 여행 상품"
         className={`${styles.navButton} ${styles.navButtonNext}`}
         onClick={nextTravel}
       >
-        <img src={chevronRight} className={styles.navButtonIcon} />
+        <img src={chevronRight} className={styles.navButtonIcon} alt="" />
       </button>
     </div>
   );

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -61,7 +61,7 @@ const TravelSection = () => {
 
   return (
     <section className={styles.travelSection} aria-roledescription="carousel">
-      <ul className={styles.carousel}>
+      <ul className={styles.carousel} id="carousel-items">
         {travelOptions.map((option, index) => (
           <li
             key={option.link}

--- a/src/index.css
+++ b/src/index.css
@@ -83,7 +83,7 @@ video {
   padding: 0;
   border: 0;
   font-size: 100%;
-  font: inherit;
+  font-family: inherit;
   vertical-align: baseline;
   box-sizing: border-box;
 }
@@ -116,4 +116,10 @@ body {
   padding: 0;
   font-family: Arial, sans-serif;
   background-color: #f5f5f5;
+}
+button {
+  all: unset;
+  display: block;
+  box-sizing: border-box;
+  cursor: pointer;
 }


### PR DESCRIPTION
## 🔥 결과

<!-- 개선 작업 후 모바일 낭독기를 사용해서 미션 페이지를 읽어보세요 -->

- 배포한 페이지 접근 경로(GitHub Pages): https://hanheel.github.io/a11y-airline/
- 스크린 리더 화면 녹화 영상 

영상 크기가 큰 관계로 드라이브에 업로드 후 링크를 첨부하였습니다

📌 before 영상
https://drive.google.com/file/d/1B9X2l8jGdX54Kin6_K0sCpCbJ-FVam29/view

1️⃣ 머리말 탐색
https://drive.google.com/file/d/15Ndz4IwYxC64j2dBbEM_bStu2p86tDFR/view?usp=sharing


2️⃣ 캐러셀 조회
https://drive.google.com/file/d/1lk4eRmLZ32w2eZ61jYKKz97RIBqLZKHW/view?usp=sharing

3️⃣ 링크 탐색
https://drive.google.com/file/d/1GRfoEM66GsPcluDeQxWMB1KUXK_EPVJh/view?usp=sharing

## ✅ 개선 작업 목록

<!-- 각 요구 사항을 위해 어떤 부분을 고민/학습해보았고, 결과적으로 어떤 개선 작업을 진행했는지 적어주세요-->

**1 컴포넌트 접근성 개선 - 이미지 캐로셀**

<details>
<summary>체크리스트</summary>
- [x] 스크린 리더가 캐로셀의 전체 아이템 수를 읽을 수 있어야 합니다.
- [x] 스크린 리더가 이미지 캐로셀 내 각 아이템 정보를 읽을 수 있어야 합니다.
  - [x] 여행지, 좌석 유형, 가격 정보를 한번에 읽을 수 있어야 합니다.
  - [x] 이전/다음 아이템으로 이동하고 현재 보이는 아이템의 정보를 읽을 수 있어야 합니다.
- [x] 각 아이템을 선택하면 각각에 맞는 링크로 이동할 수 있어야 합니다.
</details>

### 캐러셀 요소에 대한 설명 추가

1. "총 몇 개 중 몇 번째 항목"인지에 대한 설명 추가 c57606da59745ef791d020eb21006b34c7d306c1
* `visually-hidden` 클래스를 통해 요소 배치에는 영향을 주지 않으나, 스크린 리더에는 위 설명이 읽히도록 설정
2. 캐러셀 내부 텍스트를 한 번에 읽도록 설정 5a55b5995e69a931a0a62c02f90191c1534af803
* aria-labelledby : 타입 / 금액 / 목적지 읽기
* aria-describedby : 버튼에 대한 설명 (누르면 예약 페이지로 이동해요) 읽기
3. 좌 / 우 이동 버튼에 대한 설명 추가 b583ae961117e4a7d00ed5860b3a68e32f0b43cd
<img width="200" alt="image" src="https://github.com/user-attachments/assets/77383573-2da7-4ba4-9f51-239a9a5d8237" />

* 이전 요소로 이동하는 버튼 - 이전 여행 상품 / 오른쪽으로 이동하는 버튼 - 다음 여행 상품

### DOM 구조 수정
1. 캐러셀 요소를 먼저 읽고 좌 / 우 이동버튼을 읽도록 버튼을 캐러셀 요소 하단으로 이동 15572f3a31bcc3676015d15fde8a5164e609652f
사진과 같은 순서대로 읽도록 구조 수정
<img width="400" alt="스크린샷 2025-09-30 오전 12 55 46" src="https://github.com/user-attachments/assets/d89b5e6e-dab7-4106-971e-43b72e36f635" />

2. 캐러셀 시멘틱 태그 추가 4211d7117fdd6ff8f698c051e042c07e3f4439a5
* ul / li 태그 활용 
* 스크린 리더가 숨겨진 항목을 읽진 않지만, "목록"이라는 컨테이너가 존재함을 인지할 수 있음

### 눈에 보이는 요소만 읽도록 설정
현재 캐러셀 요소만 읽도록 설정 03785454a14f15af8c4de474bc3e3be24ca0bd55
* 기존에는 화면에 보이지 않는 다른 캐러셀 요소들도 함께 읽었음
* 화면에 보이지 않는 캐러셀 요소는 aria-hidden을 통해 읽지 않도록 설정

**2 페이지 접근성 개선**

<details>
<summary>체크리스트</summary>
- [x] 페이지를 하나의 문서로 읽을 수 있어야 합니다.
  - [x] 페이지에 적절한 제목(title)을 제공하세요. 제목은 페이지의 주요 내용을 간결하게 설명해야 합니다.
  - [x] 페이지의 주요 영역을 시맨틱 태그를 사용해 명확히 구분해 주세요
  - [x] 헤딩을 논리적인 순서로 사용해 페이지 구조를 명확히 해주세요
- [x] 키보드 사용자를 위해 페이지 최상단에 '본문으로 바로가기' 링크를 제공해 반복되는 메뉴를 건너뛸 수 있게 해주세요
</details>

1. DOM 구조 개선 aafb7c58ebe623b7e49e703e033e149518af106c
header / section / main / footer 등 시맨틱 태그를 사용한 DOM 구조 개선

2. skipLink 설정 ea46f7e3566e2de4d1f2ac89f4317f01597627a9
기본적으로는 보이지 않고, focus 시에만 노출되도록 설정
해당 버튼을 통해 빠르게 메인 요소로 이동하여 탐색할 수 있음
<img width="500" alt="image" src="https://github.com/user-attachments/assets/7feea5bb-66db-4cfb-8fd6-0b24f5e4774f" />

3. title 설정 ea42938a48793145a845e77c58f7d7c005f2fcca
title 태그를 통해 페이지 설명 추가

4. 새로고침시 aria-live 요소를 읽지 않도록 설정 cdd3cc65fe41dc0f0280934b306e9ec9fcabc828
기존에는 페이지가 새로고침될 때, 하단에 있는 캐러셀 요소의 설명(예: “n개의 상품 중 1번째”)이 먼저 스크린 리더에 의해 읽힘. 이로 인해 사용자가 페이지의 주제나 성격을 나타내는 상단 요소(h1 등)에 접근하기 전에 불필요한 맥락을 먼저 듣게 되는 문제 발생
새로고침시 캐러셀 설명이 자동으로 읽히지 않도록 설정

5. 한 페이지당 h1 은 하나만 들어가도록 설정 045eb92c7ee7c562017571aaa4f4bc2f0f027df8
heading1 요소는 해당 페이지를 대표하는 설명 -> "지금 떠나기 좋은 여행"을 h1에서 h2로 변경하여 명확한 위계 구조 확립

## 🧐 우리 팀의 접근성 체크리스트

사진 조회 기능을 중심으로
- 페이지 첫 진입 시 h1이 존재하며, 해당 페이지의 목적을 명확히 설명하는가?
- 무한 스크롤로 새 콘텐츠가 로드될 때, 스크린 리더 사용자에게 알림(예: “새로운 사진 10장이 로드되었습니다”)이 제공되는가?
- 사진 단건 조회 버튼은 이미지 alt와 버튼 라벨이 통합되어, 사진의 의미와 상태(선택 여부 등)를 모두 전달하는가?
- 반복되는 이미지 버튼 탐색을 건너뛰고 상단으로 바로 이동할 수 있는 “맨 위로 이동/Skip 링크”가 제공되는가?
