### PR TITLE
[항공사 웹사이트의 컴포넌트 접근성 높이기] 세라(김세빈) 미션 제출합니다.

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>React App</title>
+  <title>A11Y AIRLINE - 항공편 예약 및 여행 서비스</title>
 </head>
 
 <body>

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "deploy": "npm run build && npx gh-pages -d dist"
   },
   "author": "woowacourse",
-  "homepage": "https://{username}.github.io/a11y-airline",
+  "homepage": "https://keemsebin.github.io/a11y-airline",
   "license": "MIT",
   "dependencies": {
     "react": "^18.3.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,7 +24,7 @@ function App() {
           <FlightBooking />
         </section>
         <section className={styles.travelSection}>
-          <h1 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h1>
+          <h2 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h2>
           <TravelSection />
         </section>
       </main>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,32 +2,36 @@ import styles from './App.module.css';
 import Navigation from './components/Navigation';
 import FlightBooking from './components/FlightBooking';
 import TravelSection from './components/TravelSection';
-// import PromotionModal from './components/PromotionModal';
+import PromotionModal from './components/PromotionModal';
 
 function App() {
   return (
     <div className={styles.app}>
-      <Navigation />
-      <div className={styles.header}>
-        <h1 className={`${styles.title} heading-1-text`}>A11Y AIRLINE</h1>
-        <p className="body-text">
-          A11Y AIRLINE은 고객 여러분의 안전하고 쾌적한 여행을 위해 최선을 다하고 있습니다.
-        </p>
-      </div>
-      <div id="main-content" className={styles.main}>
-        <div className={styles.flightBooking}>
-          <FlightBooking />
+      <a href="#main-content" className="visually-hidden">
+        본문으로 바로가기
+      </a>
+      <header>
+        <Navigation />
+        <div className={styles.header}>
+          <h1 className={`${styles.title} heading-1-text`}>A11Y AIRLINE</h1>
+          <p className="body-text">
+            A11Y AIRLINE은 고객 여러분의 안전하고 쾌적한 여행을 위해 최선을 다하고 있습니다.
+          </p>
         </div>
-        <div className={styles.travelSection}>
+      </header>
+      <main id="main-content" className={styles.main}>
+        <section className={styles.flightBooking}>
+          <FlightBooking />
+        </section>
+        <section className={styles.travelSection}>
           <h1 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h1>
           <TravelSection />
-        </div>
-      </div>
-      <div className={styles.footer}>
+        </section>
+      </main>
+      <footer className={styles.footer}>
         <p className="body-text">&copy; A11Y AIRLINE</p>
-      </div>
-      {/* 추가 CHALLENGE: 모달 포커스 트랩 */}
-      {/* <PromotionModal /> */}
+      </footer>
+      <PromotionModal />
     </div>
   );
 }

--- a/src/components/FlightBooking.tsx
+++ b/src/components/FlightBooking.tsx
@@ -46,22 +46,22 @@ const FlightBooking = () => {
             className={styles.helpIconWrapper}
             onMouseEnter={() => setShowTooltip(true)}
             onMouseLeave={() => setShowTooltip(false)}
-            onFocus={() => setShowTooltip(true)}
-            onBlur={() => setShowTooltip(false)}
-            aria-describedby={showTooltip ? 'passenger-help-tooltip' : undefined}
+            onClick={() => setShowTooltip((prev) => !prev)}
             aria-label="승객 수 제한 도움말"
+            aria-describedby={showTooltip ? 'passenger-help-tooltip' : undefined}
           >
             <img src={helpIcon} alt="" className={styles.helpIcon} />
-            <div
-              role="tooltip"
-              id="passenger-help-tooltip"
-              className={styles.tooltip}
-              aria-live="polite"
-              aria-hidden={!showTooltip}
-              hidden={!showTooltip}
-            >
-              최대 3명까지 예약할 수 있습니다.
-            </div>
+            {showTooltip && (
+              <div
+                id="passenger-help-tooltip"
+                role="tooltip"
+                className={styles.tooltip}
+                aria-live="polite"
+                aria-hidden={!showTooltip}
+              >
+                최대 3명까지 예약할 수 있습니다
+              </div>
+            )}
           </div>
         </div>
         <div className={styles.counter}>

--- a/src/components/FlightBooking.tsx
+++ b/src/components/FlightBooking.tsx
@@ -41,20 +41,45 @@ const FlightBooking = () => {
         <div className={styles.passengerLabel}>
           <span className="body-text">성인</span>
           <div
+            role="button"
+            tabIndex={0}
             className={styles.helpIconWrapper}
             onMouseEnter={() => setShowTooltip(true)}
             onMouseLeave={() => setShowTooltip(false)}
+            onFocus={() => setShowTooltip(true)}
+            onBlur={() => setShowTooltip(false)}
+            aria-describedby={showTooltip ? 'passenger-help-tooltip' : undefined}
+            aria-label="승객 수 제한 도움말"
           >
-            <img src={helpIcon} alt="도움말" className={styles.helpIcon} />
-            {showTooltip && <div className={styles.tooltip}>최대 3명까지 예약할 수 있습니다</div>}
+            <img src={helpIcon} alt="" className={styles.helpIcon} />
+            <div
+              role="tooltip"
+              id="passenger-help-tooltip"
+              className={styles.tooltip}
+              aria-live="polite"
+              aria-hidden={!showTooltip}
+              hidden={!showTooltip}
+            >
+              최대 3명까지 예약할 수 있습니다.
+            </div>
           </div>
         </div>
         <div className={styles.counter}>
-          <button className="button-text" onClick={decrementCount} aria-label="성인 승객 감소">
+          <button
+            className="button-text"
+            onClick={decrementCount}
+            aria-label="성인 승객 감소"
+            disabled={adultCount === MIN_PASSENGERS}
+          >
             <img src={minus} alt="" />
           </button>
           <span aria-live="polite">{adultCount}</span>
-          <button className="button-text" onClick={incrementCount} aria-label="성인 승객 증가">
+          <button
+            className="button-text"
+            onClick={incrementCount}
+            aria-label="성인 승객 증가"
+            disabled={adultCount >= MAX_PASSENGERS}
+          >
             <img src={plus} alt="" />
           </button>
         </div>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -47,7 +47,7 @@ const Navigation = () => {
   const renderNavItems = (items: NavItem[]) => (
     <ul className={styles.navList}>
       {items.map((item, index) => (
-        <li key={index} className={styles.navItem}>
+        <li key={index} aria-haspopup="true" aria-expanded={isNavOpen} className={styles.navItem}>
           <a href={item.link}>{item.title}</a>
           {item.subItems && renderNavItems(item.subItems)}
         </li>
@@ -57,10 +57,19 @@ const Navigation = () => {
 
   return (
     <>
-      <button className={styles.navToggle} onClick={toggleNav}>
+      <button
+        className={styles.navToggle}
+        onClick={toggleNav}
+        aria-controls="main-nav"
+        aria-expanded={isNavOpen}
+      >
         {isNavOpen ? '닫기' : '메뉴'}
       </button>
-      <nav id="main-nav" className={`${styles.mainNav} ${isNavOpen ? styles.mainNavActive : ''}`}>
+      <nav
+        id="main-nav"
+        aria-label="주요 메뉴"
+        className={`${styles.mainNav} ${isNavOpen ? styles.mainNavActive : ''}`}
+      >
         {renderNavItems(navItems)}
       </nav>
     </>

--- a/src/components/PromotionModal.tsx
+++ b/src/components/PromotionModal.tsx
@@ -33,18 +33,18 @@ const PromotionModal = () => {
       </div>
       <div
         className={styles.modal}
-        role="alertdialog"
+        role="dialog"
         aria-modal="true"
         aria-labelledby="promotion-modal-title"
         aria-describedby="promotion-modal-description"
       >
-        <div aria-hidden="false" className={styles.modalBackdrop} onClick={closeModal}></div>
+        <div aria-hidden="true" className={styles.modalBackdrop} onClick={closeModal}></div>
         <div ref={modalRef} className={styles.modalContainer}>
           <div className={styles.modalContent}>
             <h2 id="promotion-modal-title" className={`${styles.modalTitle} heading-2-text`}>
               여행할 땐 A11Y AIRLINE 앱
             </h2>
-            <p id="promotion-modal-description" className={`${styles.modalDescription} body-text`}>
+            <p className={`${styles.modalDescription} body-text`}>
               체크인, 탑승권 저장, 수하물 알림까지
               <br />- 앱으로 더욱 편하게 여행하세요!
             </p>

--- a/src/components/PromotionModal.tsx
+++ b/src/components/PromotionModal.tsx
@@ -1,37 +1,65 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import close from '../assets/close.svg';
 
 import styles from './PromotionModal.module.css';
+import { useFocusTrap } from '../hooks/useFocusTrap';
 
 const PromotionModal = () => {
   const [isOpen, setIsOpen] = useState(true);
+  const modalRef = useRef<HTMLDivElement | null>(null);
+  useFocusTrap(modalRef);
 
   const closeModal = () => {
     setIsOpen(false);
   };
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') closeModal();
+    };
+    if (isOpen) document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen]);
 
   if (!isOpen) {
     return null;
   }
 
   return (
-    <div className={styles.modal}>
-      <div className={styles.modalBackdrop} onClick={closeModal}></div>
-      <div className={styles.modalContainer}>
-        <div className={styles.modalContent}>
-          <h2 className={`${styles.modalTitle} heading-2-text`}>여행할 땐 A11Y AIRLINE 앱</h2>
-          <p className={`${styles.modalDescription} body-text`}>
-            체크인, 탑승권 저장, 수하물 알림까지
-            <br />- 앱으로 더욱 편하게 여행하세요!
-          </p>
-          <button className={`${styles.modalActionButton} button-text`}>앱에서 열기</button>
-          <button className={`${styles.modalCloseButton} heading-2-text`} onClick={closeModal}>
-            <img src={close} />
-          </button>
+    <>
+      <div role="status" aria-live="assertive" className="visually-hidden">
+        프로모션 모달이 열렸습니다.
+      </div>
+      <div
+        className={styles.modal}
+        role="alertdialog"
+        aria-modal="true"
+        aria-labelledby="promotion-modal-title"
+        aria-describedby="promotion-modal-description"
+      >
+        <div aria-hidden="false" className={styles.modalBackdrop} onClick={closeModal}></div>
+        <div ref={modalRef} className={styles.modalContainer}>
+          <div className={styles.modalContent}>
+            <h2 id="promotion-modal-title" className={`${styles.modalTitle} heading-2-text`}>
+              여행할 땐 A11Y AIRLINE 앱
+            </h2>
+            <p id="promotion-modal-description" className={`${styles.modalDescription} body-text`}>
+              체크인, 탑승권 저장, 수하물 알림까지
+              <br />- 앱으로 더욱 편하게 여행하세요!
+            </p>
+            <button className={`${styles.modalActionButton} button-text`}>앱에서 열기</button>
+            <button
+              aria-label="프로모션 모달 닫기"
+              className={`${styles.modalCloseButton} heading-2-text`}
+              onClick={closeModal}
+            >
+              <img src={close} alt="" aria-hidden="true" />
+            </button>
+          </div>
         </div>
       </div>
-    </div>
+    </>
   );
 };
 

--- a/src/components/TravelSection.module.css
+++ b/src/components/TravelSection.module.css
@@ -21,6 +21,7 @@
 
 .cardActive {
   display: block;
+  color: black;
 }
 
 .cardImage {

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -61,12 +61,15 @@ const TravelSection = () => {
 
   return (
     <div aria-roledescription="carousel" className={styles.travelSection}>
-      <div role="tabpanel" aria-live="polite" aria-atomic="false" className={styles.carousel}>
-        <span className="visually-hidden">
-          총 ${travelOptions.length}개의 상품 중 ${currentIndex + 1}번째 여행 상품
-        </span>
+      <span className="visually-hidden">
+        {`총 ${travelOptions.length}개의 상품 중 ${currentIndex + 1}번째 여행 상품`}
+      </span>
+      <div role="region" aria-live="polite" aria-atomic="false" className={styles.carousel}>
         {travelOptions.map((option, index) => (
           <a
+            href={option.link}
+            target="_blank"
+            rel="noopener noreferrer"
             key={index}
             aria-label={`${option.departure} 출발 ${option.destination} 도착, ${
               option.type

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -61,9 +61,6 @@ const TravelSection = () => {
 
   return (
     <div aria-roledescription="carousel" className={styles.travelSection}>
-      <button className={`${styles.navButton} ${styles.navButtonPrev}`} onClick={prevTravel}>
-        <img src={chevronLeft} className={styles.navButtonIcon} />
-      </button>
       <div role="tabpanel" aria-live="polite" aria-atomic="false" className={styles.carousel}>
         <span className="visually-hidden">{`총 ${travelOptions.length}개의 상품 중 ${
           currentIndex + 1
@@ -74,7 +71,7 @@ const TravelSection = () => {
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
             onClick={() => handleCardClick(option.link)}
           >
-            <img src={option.image} className={styles.cardImage} aria-hidden="true" />
+            <img src={option.image} className={styles.cardImage} alt="" aria-hidden="true" />
             <div className={styles.cardContent} aria-hidden="true">
               <p className={`${styles.cardTitle} heading-3-text`}>
                 {option.departure} - {option.destination}
@@ -85,8 +82,19 @@ const TravelSection = () => {
           </div>
         ))}
       </div>
-      <button className={`${styles.navButton} ${styles.navButtonNext}`} onClick={nextTravel}>
-        <img src={chevronRight} className={styles.navButtonIcon} />
+      <button
+        aria-label="이전 여행 상품"
+        className={`${styles.navButton} ${styles.navButtonPrev}`}
+        onClick={prevTravel}
+      >
+        <img src={chevronLeft} className={styles.navButtonIcon} alt="" />
+      </button>
+      <button
+        aria-label="다음 여행 상품"
+        className={`${styles.navButton} ${styles.navButtonNext}`}
+        onClick={nextTravel}
+      >
+        <img src={chevronRight} className={styles.navButtonIcon} alt="" />
       </button>
     </div>
   );

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -55,10 +55,6 @@ const TravelSection = () => {
     setCurrentIndex((prevIndex) => (prevIndex - 1 + travelOptions.length) % travelOptions.length);
   };
 
-  const handleCardClick = (link: string) => {
-    window.open(link, '_blank', 'noopener,noreferrer');
-  };
-
   return (
     <div aria-roledescription="carousel" className={styles.travelSection}>
       <span className="visually-hidden">
@@ -76,7 +72,6 @@ const TravelSection = () => {
             }, 가격 ${option.price.toLocaleString()} 원. 선택하면 예약 페이지로 이동합니다.`}
             aria-hidden={index !== currentIndex}
             tabIndex={index === currentIndex ? 0 : -1}
-            onClick={() => handleCardClick(option.link)}
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
           >
             <img src={option.image} className={styles.cardImage} alt="" aria-hidden="true" />

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -62,13 +62,12 @@ const TravelSection = () => {
   return (
     <div aria-roledescription="carousel" className={styles.travelSection}>
       <div role="tabpanel" aria-live="polite" aria-atomic="false" className={styles.carousel}>
-        <span className="visually-hidden">{`총 ${travelOptions.length}개의 상품 중 ${
-          currentIndex + 1
-        }번째 여행 상품`}</span>
+        <span className="visually-hidden">
+          총 ${travelOptions.length}개의 상품 중 ${currentIndex + 1}번째 여행 상품
+        </span>
         {travelOptions.map((option, index) => (
-          <div
+          <a
             key={index}
-            role="button"
             aria-label={`${option.departure} 출발 ${option.destination} 도착, ${
               option.type
             }, 가격 ${option.price.toLocaleString()} 원. 선택하면 예약 페이지로 이동합니다.`}
@@ -85,7 +84,7 @@ const TravelSection = () => {
               <p className={`${styles.cardType} body-text`}>{option.type}</p>
               <p className={`${styles.cardPrice} body-text`}>KRW {option.price.toLocaleString()}</p>
             </div>
-          </div>
+          </a>
         ))}
       </div>
       <button

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -68,8 +68,13 @@ const TravelSection = () => {
         {travelOptions.map((option, index) => (
           <div
             key={index}
-            className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
+            role="button"
+            aria-label={`${option.departure} 출발 ${option.destination} 도착, ${
+              option.type
+            }, 가격 ${option.price.toLocaleString()} 원. 선택하면 예약 페이지로 이동합니다.`}
+            aria-hidden={index !== currentIndex}
             onClick={() => handleCardClick(option.link)}
+            className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
           >
             <img src={option.image} className={styles.cardImage} alt="" aria-hidden="true" />
             <div className={styles.cardContent} aria-hidden="true">

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -73,6 +73,7 @@ const TravelSection = () => {
               option.type
             }, 가격 ${option.price.toLocaleString()} 원. 선택하면 예약 페이지로 이동합니다.`}
             aria-hidden={index !== currentIndex}
+            tabIndex={index === currentIndex ? 0 : -1}
             onClick={() => handleCardClick(option.link)}
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
           >

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -60,19 +60,22 @@ const TravelSection = () => {
   };
 
   return (
-    <div className={styles.travelSection}>
+    <div aria-roledescription="carousel" className={styles.travelSection}>
       <button className={`${styles.navButton} ${styles.navButtonPrev}`} onClick={prevTravel}>
         <img src={chevronLeft} className={styles.navButtonIcon} />
       </button>
-      <div className={styles.carousel}>
+      <div role="tabpanel" aria-live="polite" aria-atomic="false" className={styles.carousel}>
+        <span className="visually-hidden">{`총 ${travelOptions.length}개의 상품 중 ${
+          currentIndex + 1
+        }번째 여행 상품`}</span>
         {travelOptions.map((option, index) => (
           <div
             key={index}
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
             onClick={() => handleCardClick(option.link)}
           >
-            <img src={option.image} className={styles.cardImage} />
-            <div className={styles.cardContent}>
+            <img src={option.image} className={styles.cardImage} aria-hidden="true" />
+            <div className={styles.cardContent} aria-hidden="true">
               <p className={`${styles.cardTitle} heading-3-text`}>
                 {option.departure} - {option.destination}
               </p>

--- a/src/hooks/useFocusTrap.tsx
+++ b/src/hooks/useFocusTrap.tsx
@@ -1,0 +1,33 @@
+import { RefObject, useEffect } from 'react';
+
+export const useFocusTrap = (containerRef: RefObject<HTMLElement | null>) => {
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const focusableElements = container.querySelectorAll<HTMLElement>(
+      'button, a[href], input, textarea, select, [tabindex]:not([tabindex="-1"])'
+    );
+    const first = focusableElements[0];
+    const last = focusableElements[focusableElements.length - 1];
+
+    first?.focus();
+
+    const handleTab = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab' || !first || !last) return;
+
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+
+    container.addEventListener('keydown', handleTab);
+    return () => {
+      container.removeEventListener('keydown', handleTab);
+    };
+  }, [containerRef]);
+};


### PR DESCRIPTION
안녕하세요 리바이~! 이전 미션 리뷰어였는데 역전 됐군용 ㅋ.ㅋ 
요번 미션 잘 부탁드려요~! 어떤 것들을 적용했는지는 [노션](https://nosy-radium-d17.notion.site/27d91a88167580fc96a2c5336d8c12bb?source=copy_link)에 적어뒀어요. 참고 부탁드려요!

## 🔥 결과

<!-- 개선 작업 후 모바일 낭독기를 사용해서 미션 페이지를 읽어보세요 -->

- 배포한 페이지 접근 경로(GitHub Pages): [배포 주소](https://keemsebin.github.io/a11y-airline/)
- 스크린 리더 화면 녹화 영상 (before / after) : [노션](https://nosy-radium-d17.notion.site/27d91a88167580fc96a2c5336d8c12bb?source=copy_link)

## ✅ 개선 작업 목록

<!-- 각 요구 사항을 위해 어떤 부분을 고민/학습해보았고, 결과적으로 어떤 개선 작업을 진행했는지 적어주세요-->

**1 컴포넌트 접근성 개선 - 이미지 캐로셀**

- [x] 스크린 리더가 캐로셀의 전체 아이템 수를 읽을 수 있어야 합니다.
- [x] 스크린 리더가 이미지 캐로셀 내 각 아이템 정보를 읽을 수 있어야 합니다.
  - [x] 여행지, 좌석 유형, 가격 정보를 한번에 읽을 수 있어야 합니다.
  - [x] 이전/다음 아이템으로 이동하고 현재 보이는 아이템의 정보를 읽을 수 있어야 합니다.
- [x] 각 아이템을 선택하면 각각에 맞는 링크로 이동할 수 있어야 합니다.

**2 페이지 접근성 개선**

- [x] 페이지를 하나의 문서로 읽을 수 있어야 합니다.
  - [x] 페이지에 적절한 제목(title)을 제공하세요. 제목은 페이지의 주요 내용을 간결하게 설명해야 합니다.
  - [x] 페이지의 주요 영역을 시맨틱 태그를 사용해 명확히 구분해 주세요
  - [x] 헤딩을 논리적인 순서로 사용해 페이지 구조를 명확히 해주세요
- [x] 키보드 사용자를 위해 페이지 최상단에 '본문으로 바로가기' 링크를 제공해 반복되는 메뉴를 건너뛸 수 있게 해주세요

## 🧐 우리 팀의 접근성 체크리스트

###  우리 팀 서비스에서 가장 중요하고 자주 사용되는 기능 플로우 1개를 선택하고 간단히 나열해 주세요. 
조직 선택 - 이벤트 전체 조회 - 이벤트 상세조회 

### 질문 리스트 
1. 화면을 볼 수 없는 사용자가 이 단계를 완료할 수 있는가?
현재 시맨틱 구조가 적절하지 않고, Tab 이동 시에도 role이나 aria 속성이 부족하여 사용자가 현재 위치나 목적을 인지하기 어렵다고 생각합니다. 또한 각 카드 컴포넌트에서 충분한 상세 정보를 제공하지 않아, 사용자가 필요한 정보를 파악하기 어렵습니다. 
2. 이 단계에서 제공하는 정보나 지시 사항이 모든 사용자에게 명확한가?
`모든 사용자에게 명확한가?`라는 부분에 대해서는 판단이 다소 어렵다고 생각이 드는데요. 리바이의 관점에서는 이 단계가 사용자에게 명확하게 인식되는지 어떻게 보이나요?? 의견이 궁금합니다~!