### PR TITLE
[항공사 웹사이트의 컴포넌트 접근성 높이기] 상추(이상희) 미션 제출합니다.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,15 +1,13 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>A11Y AIRLINE</title>
+  </head>
 
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>React App</title>
-</head>
-
-<body>
-  <div id="root"></div>
-  <script type="module" src="/src/main.tsx"></script>
-</body>
-
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "deploy": "npm run build && npx gh-pages -d dist"
   },
   "author": "woowacourse",
-  "homepage": "https://{username}.github.io/a11y-airline",
+  "homepage": "https://sanghee01.github.io/a11y-airline",
   "license": "MIT",
   "dependencies": {
     "react": "^18.3.1",

--- a/src/Accessibility.css
+++ b/src/Accessibility.css
@@ -9,3 +9,20 @@
   white-space: nowrap;
   border: 0;
 }
+
+.skip-link {
+  position: absolute;
+  top: -40px;
+  left: 6px;
+  background: #0969da;
+  color: white;
+  padding: 12px 16px;
+  text-decoration: none;
+  border-radius: 4px;
+  font-size: 14px;
+  z-index: 1000;
+}
+
+.skip-link:focus {
+  top: 6px;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,13 +18,13 @@ function App() {
         </p>
       </header>
       <main id="main-content" className={styles.main}>
-        <div className={styles.flightBooking}>
+        <section className={styles.flightBooking}>
           <FlightBooking />
-        </div>
-        <div className={styles.travelSection}>
+        </section>
+        <section className={styles.travelSection}>
           <h2 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h2>
           <TravelSection />
-        </div>
+        </section>
       </main>
       <footer className={styles.footer}>
         <p className="body-text">&copy; A11Y AIRLINE</p>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,9 @@ import TravelSection from './components/TravelSection';
 function App() {
   return (
     <div className={styles.app}>
+      <a href="#main-content" className="skip-link">
+        본문으로 바로가기
+      </a>
       <Navigation />
       <header className={styles.header}>
         <h1 className={`${styles.title} heading-1-text`}>A11Y AIRLINE</h1>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,24 +8,24 @@ function App() {
   return (
     <div className={styles.app}>
       <Navigation />
-      <div className={styles.header}>
+      <header className={styles.header}>
         <h1 className={`${styles.title} heading-1-text`}>A11Y AIRLINE</h1>
         <p className="body-text">
           A11Y AIRLINE은 고객 여러분의 안전하고 쾌적한 여행을 위해 최선을 다하고 있습니다.
         </p>
-      </div>
-      <div id="main-content" className={styles.main}>
+      </header>
+      <main id="main-content" className={styles.main}>
         <div className={styles.flightBooking}>
           <FlightBooking />
         </div>
         <div className={styles.travelSection}>
-          <h1 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h1>
+          <h2 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h2>
           <TravelSection />
         </div>
-      </div>
-      <div className={styles.footer}>
+      </main>
+      <footer className={styles.footer}>
         <p className="body-text">&copy; A11Y AIRLINE</p>
-      </div>
+      </footer>
       {/* 추가 CHALLENGE: 모달 포커스 트랩 */}
       {/* <PromotionModal /> */}
     </div>

--- a/src/components/FlightBooking.module.css
+++ b/src/components/FlightBooking.module.css
@@ -14,6 +14,8 @@
   position: relative;
   margin-left: 5px;
   cursor: pointer;
+  background: none;
+  border: none;
 }
 
 .helpIcon {

--- a/src/components/FlightBooking.tsx
+++ b/src/components/FlightBooking.tsx
@@ -35,19 +35,27 @@ const FlightBooking = () => {
   }, [adultCount]);
 
   return (
-    <div className={styles.flightBooking}>
+    <section className={styles.flightBooking}>
       <h2 className="heading-2-text">항공권 예매</h2>
       <div className={styles.passengerCount}>
         <div className={styles.passengerLabel}>
           <span className="body-text">성인</span>
-          <div
+          <button
             className={styles.helpIconWrapper}
             onMouseEnter={() => setShowTooltip(true)}
             onMouseLeave={() => setShowTooltip(false)}
+            onFocus={() => setShowTooltip(true)}
+            onBlur={() => setShowTooltip(false)}
+            aria-describedby={showTooltip ? 'passenger-help' : undefined}
+            aria-label="승객 수 도움말"
           >
-            <img src={helpIcon} alt="도움말" className={styles.helpIcon} />
-            {showTooltip && <div className={styles.tooltip}>최대 3명까지 예약할 수 있습니다</div>}
-          </div>
+            <img src={helpIcon} alt="" className={styles.helpIcon} />
+            {showTooltip && (
+              <div id="passenger-help" className={styles.tooltip} aria-live="polite">
+                최대 3명까지 예약할 수 있습니다
+              </div>
+            )}
+          </button>
         </div>
         <div className={styles.counter}>
           <button className="button-text" onClick={decrementCount} aria-label="성인 승객 감소">
@@ -65,7 +73,7 @@ const FlightBooking = () => {
         </div>
       )}
       <button className={styles.searchButton}>항공편 검색</button>
-    </div>
+    </section>
   );
 };
 

--- a/src/components/TravelSection.module.css
+++ b/src/components/TravelSection.module.css
@@ -87,3 +87,15 @@
   width: 24px;
   height: 24px;
 }
+
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/src/components/TravelSection.module.css
+++ b/src/components/TravelSection.module.css
@@ -17,6 +17,7 @@
   display: none;
   width: 100%;
   height: 246px;
+  color: inherit;
 }
 
 .cardActive {

--- a/src/components/TravelSection.module.css
+++ b/src/components/TravelSection.module.css
@@ -87,15 +87,3 @@
   width: 24px;
   height: 24px;
 }
-
-.srOnly {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
-}

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -62,7 +62,7 @@ const TravelSection = () => {
   return (
     <div className={styles.travelSection}>
       <button className={`${styles.navButton} ${styles.navButtonPrev}`} onClick={prevTravel}>
-        <img src={chevronLeft} className={styles.navButtonIcon} />
+        <img src={chevronLeft} className={styles.navButtonIcon} alt="" />
       </button>
       <div className={styles.carousel}>
         {travelOptions.map((option, index) => (
@@ -71,7 +71,11 @@ const TravelSection = () => {
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
             onClick={() => handleCardClick(option.link)}
           >
-            <img src={option.image} className={styles.cardImage} />
+            <img
+              src={option.image}
+              className={styles.cardImage}
+              alt={`${option.destination} 여행 상품`}
+            />
             <div className={styles.cardContent}>
               <p className={`${styles.cardTitle} heading-3-text`}>
                 {option.departure} - {option.destination}
@@ -83,7 +87,7 @@ const TravelSection = () => {
         ))}
       </div>
       <button className={`${styles.navButton} ${styles.navButtonNext}`} onClick={nextTravel}>
-        <img src={chevronRight} className={styles.navButtonIcon} />
+        <img src={chevronRight} className={styles.navButtonIcon} alt="" />
       </button>
     </div>
   );

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -56,11 +56,9 @@ const TravelSection = () => {
   };
 
   return (
-    <section className={styles.travelSection} aria-label="세계 여행 상품">
-      <button className={`${styles.navButton} ${styles.navButtonPrev}`} onClick={prevTravel}>
-        <img src={chevronLeft} className={styles.navButtonIcon} alt="" />
-      </button>
-      <div className={styles.carousel}>
+    <section className={styles.travelSection}>
+      <div className={styles.carousel} aria-live="polite">
+        <div className={styles.srOnly}>{`세계의 여행상품 중 ${currentIndex + 1}번째 상품`}</div>
         {travelOptions.map((option, index) => (
           <a
             key={index}
@@ -68,13 +66,12 @@ const TravelSection = () => {
             target="_blank"
             rel="noopener noreferrer"
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
+            aria-label={`${option.departure} 출발 ${option.destination} 도착, ${
+              option.type
+            }, 가격 ${option.price.toLocaleString()}원, 선택하면 예약페이지로 이동합니다`}
           >
-            <img
-              src={option.image}
-              className={styles.cardImage}
-              alt={`${option.destination} 여행 상품`}
-            />
-            <div className={styles.cardContent}>
+            <img src={option.image} className={styles.cardImage} alt="" />
+            <div className={styles.cardContent} aria-hidden="true">
               <p className={`${styles.cardTitle} heading-3-text`}>
                 {option.departure} - {option.destination}
               </p>
@@ -84,7 +81,18 @@ const TravelSection = () => {
           </a>
         ))}
       </div>
-      <button className={`${styles.navButton} ${styles.navButtonNext}`} onClick={nextTravel}>
+      <button
+        className={`${styles.navButton} ${styles.navButtonPrev}`}
+        onClick={prevTravel}
+        aria-label="이전"
+      >
+        <img src={chevronLeft} className={styles.navButtonIcon} alt="" />
+      </button>
+      <button
+        className={`${styles.navButton} ${styles.navButtonNext}`}
+        onClick={nextTravel}
+        aria-label="다음"
+      >
         <img src={chevronRight} className={styles.navButtonIcon} alt="" />
       </button>
     </section>

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -56,7 +56,7 @@ const TravelSection = () => {
   };
 
   return (
-    <div className={styles.travelSection}>
+    <section className={styles.travelSection} aria-label="세계 여행 상품">
       <button className={`${styles.navButton} ${styles.navButtonPrev}`} onClick={prevTravel}>
         <img src={chevronLeft} className={styles.navButtonIcon} alt="" />
       </button>
@@ -87,7 +87,7 @@ const TravelSection = () => {
       <button className={`${styles.navButton} ${styles.navButtonNext}`} onClick={nextTravel}>
         <img src={chevronRight} className={styles.navButtonIcon} alt="" />
       </button>
-    </div>
+    </section>
   );
 };
 

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -58,7 +58,7 @@ const TravelSection = () => {
   return (
     <div className={styles.travelSection}>
       <div className={styles.carousel} aria-live="polite">
-        <div className={styles.srOnly}>{`세계의 여행상품 중 ${currentIndex + 1}번째 상품`}</div>
+        <div className="visually-hidden">{`세계의 여행상품 중 ${currentIndex + 1}번째 상품`}</div>
         {travelOptions.map((option, index) => (
           <a
             key={index}

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -55,10 +55,6 @@ const TravelSection = () => {
     setCurrentIndex((prevIndex) => (prevIndex - 1 + travelOptions.length) % travelOptions.length);
   };
 
-  const handleCardClick = (link: string) => {
-    window.open(link, '_blank', 'noopener,noreferrer');
-  };
-
   return (
     <div className={styles.travelSection}>
       <button className={`${styles.navButton} ${styles.navButtonPrev}`} onClick={prevTravel}>
@@ -66,10 +62,12 @@ const TravelSection = () => {
       </button>
       <div className={styles.carousel}>
         {travelOptions.map((option, index) => (
-          <div
+          <a
             key={index}
+            href={option.link}
+            target="_blank"
+            rel="noopener noreferrer"
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
-            onClick={() => handleCardClick(option.link)}
           >
             <img
               src={option.image}
@@ -83,7 +81,7 @@ const TravelSection = () => {
               <p className={`${styles.cardType} body-text`}>{option.type}</p>
               <p className={`${styles.cardPrice} body-text`}>KRW {option.price.toLocaleString()}</p>
             </div>
-          </div>
+          </a>
         ))}
       </div>
       <button className={`${styles.navButton} ${styles.navButtonNext}`} onClick={nextTravel}>

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -56,7 +56,7 @@ const TravelSection = () => {
   };
 
   return (
-    <section className={styles.travelSection}>
+    <div className={styles.travelSection}>
       <div className={styles.carousel} aria-live="polite">
         <div className={styles.srOnly}>{`세계의 여행상품 중 ${currentIndex + 1}번째 상품`}</div>
         {travelOptions.map((option, index) => (
@@ -95,7 +95,7 @@ const TravelSection = () => {
       >
         <img src={chevronRight} className={styles.navButtonIcon} alt="" />
       </button>
-    </section>
+    </div>
   );
 };
 

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -57,30 +57,34 @@ const TravelSection = () => {
 
   return (
     <div className={styles.travelSection}>
-      <div className={styles.carousel} aria-live="polite">
+      <ul className={styles.carousel} aria-live="polite">
         <div className="visually-hidden">{`세계의 여행상품 중 ${currentIndex + 1}번째 상품`}</div>
+
         {travelOptions.map((option, index) => (
-          <a
-            key={index}
-            href={option.link}
-            target="_blank"
-            rel="noopener noreferrer"
-            className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
-            aria-label={`${option.departure} 출발 ${option.destination} 도착, ${
-              option.type
-            }, 가격 ${option.price.toLocaleString()}원, 선택하면 예약페이지로 이동합니다`}
-          >
-            <img src={option.image} className={styles.cardImage} alt="" />
-            <div className={styles.cardContent} aria-hidden="true">
-              <p className={`${styles.cardTitle} heading-3-text`}>
-                {option.departure} - {option.destination}
-              </p>
-              <p className={`${styles.cardType} body-text`}>{option.type}</p>
-              <p className={`${styles.cardPrice} body-text`}>KRW {option.price.toLocaleString()}</p>
-            </div>
-          </a>
+          <li key={index}>
+            <a
+              href={option.link}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
+              aria-label={`${option.departure} 출발 ${option.destination} 도착, ${
+                option.type
+              }, 가격 ${option.price.toLocaleString()}원, 선택하면 예약페이지로 이동합니다`}
+            >
+              <img src={option.image} className={styles.cardImage} alt="" />
+              <div className={styles.cardContent} aria-hidden="true">
+                <p className={`${styles.cardTitle} heading-3-text`}>
+                  {option.departure} - {option.destination}
+                </p>
+                <p className={`${styles.cardType} body-text`}>{option.type}</p>
+                <p className={`${styles.cardPrice} body-text`}>
+                  KRW {option.price.toLocaleString()}
+                </p>
+              </div>
+            </a>
+          </li>
         ))}
-      </div>
+      </ul>
       <button
         className={`${styles.navButton} ${styles.navButtonPrev}`}
         onClick={prevTravel}


### PR DESCRIPTION
안녕하세요 클레어🍀 리뷰이 상추🥬입니다
이번 미션 잘 부탁드립니다! 
의문이 드는점, 개선하면 좋을점 등등 편하게 말씀주세요!!

## 🔥 결과

<!-- 개선 작업 후 모바일 낭독기를 사용해서 미션 페이지를 읽어보세요 -->

- 배포한 페이지 접근 경로(GitHub Pages): https://sanghee01.github.io/a11y-airline/
- 스크린 리더 화면 녹화 영상 (before / after)
### before

https://github.com/user-attachments/assets/38e4459f-f76d-4e20-a39a-0f52b842973e

### after

https://github.com/user-attachments/assets/af07b431-21be-412f-b86b-89b3bfd19419

### Lighthouse 측정 결과
**before**
<img width="914" height="302" alt="image" src="https://github.com/user-attachments/assets/5808a8e5-8d7b-4fa0-986a-abcc54a2f292" />

**after**
<img width="488" height="156" alt="image" src="https://github.com/user-attachments/assets/b1a92f1f-93ac-4270-a924-b16ba628f0c4" />



## ✅ 개선 작업 목록

<!-- 각 요구 사항을 위해 어떤 부분을 고민/학습해보았고, 결과적으로 어떤 개선 작업을 진행했는지 적어주세요-->

**1 컴포넌트 접근성 개선 - 이미지 캐로셀**

- [x] 스크린 리더가 캐로셀의 전체 아이템 수를 읽을 수 있어야 합니다. [f20801b](https://github.com/woowacourse/a11y-airline/pull/165/commits/f20801b2c730fa5ee2076396082643fed40f289a)
- [x] 스크린 리더가 이미지 캐로셀 내 각 아이템 정보를 읽을 수 있어야 합니다. [b6e3fdd](https://github.com/woowacourse/a11y-airline/pull/165/commits/b6e3fddb62eb393e66a3b7bca778c0acf3504ed9)
  - [x] 여행지, 좌석 유형, 가격 정보를 한번에 읽을 수 있어야 합니다.
  - [x]  이전/다음 아이템으로 이동하고 현재 보이는 아이템의 정보를 읽을 수 있어야 합니다.
- [x] 각 아이템을 선택하면 각각에 맞는 링크로 이동할 수 있어야 합니다. [4ce7bf6](https://github.com/woowacourse/a11y-airline/pull/165/commits/4ce7bf621e41a95ddc6ba032052808f877f26b8d)

**2 페이지 접근성 개선**

- [x] 페이지를 하나의 문서로 읽을 수 있어야 합니다.
  - [x] 페이지에 적절한 제목(title)을 제공하세요. 제목은 페이지의 주요 내용을 간결하게 설명해야 합니다. [5527099](https://github.com/woowacourse/a11y-airline/pull/165/commits/5527099c55a56d5460001e6e6e10a614929e8c60)
  - [x] 페이지의 주요 영역을 시맨틱 태그를 사용해 명확히 구분해 주세요 [5e3af3c](https://github.com/woowacourse/a11y-airline/pull/165/commits/5e3af3c609a40585b4590b4e31113ad4b05ed4f8) [5c14603](https://github.com/woowacourse/a11y-airline/pull/165/commits/5c146031b849308cee9740cd1a266262e69aadda)
  - [x] 헤딩을 논리적인 순서로 사용해 페이지 구조를 명확히 해주세요 [5c14603](https://github.com/woowacourse/a11y-airline/pull/165/commits/5c146031b849308cee9740cd1a266262e69aadda)
- [x] 키보드 사용자를 위해 페이지 최상단에 '본문으로 바로가기' 링크를 제공해 반복되는 메뉴를 건너뛸 수 있게 해주세요 [fcbf86b](https://github.com/woowacourse/a11y-airline/pull/165/commits/fcbf86b1c7e868bb734d90a7c4ec0b719396d27d)

## 🧐 우리 팀의 접근성 체크리스트

<!--
우리 서비스에서 이런 부분의 접근성은 챙겨봐야겠다! 하는 체크리스트 v1을 만들고, 리뷰어와 의견을 나눠보세요
- 우리 팀 서비스에서 가장 중요하고 자주 사용되는 기능 플로우 1개를 선택하고 간단히 나열해 주세요 (예: 로그인 → 상품 검색 → 상품 선택 → 장바구니 추가 → 결제)
- 해당 플로우의 각 단계에 대해 다음 질문을 생각해 보세요.
  - 1. 화면을 볼 수 없는 사용자가 이 단계를 완료할 수 있는가?
  - 2. 이 단계에서 제공하는 정보나 지시 사항이 모든 사용자에게 명확한가?
- 질문에 대해 팀원들과 의견을 나눠본 것을 바탕으로, 우리 팀만의 접근성 체크리스트 v1을 만들고 리뷰어와 의견을 나눠보세요. (예: "모든 이미지에 적절한 대체 텍스트가 제공되는가?")
-->

[모멘트 서비스 링크](https://connectingmoment.com/)

### 모멘트 자주 사용되는 기능 플로우

로그인 -> 모멘트 작성 -> 코멘트 작성 -> 모멘트 모음집 확인 -> 코멘트 모음집 확인

### 접근성 문제
 
1. 스크린 리더기가 정보를 제대로 읽어주지 못함
- 코멘트 작성 페이지에서, 신고하기, 리롤 버튼을 “버튼”이라고만 읽어서 무슨 버튼인지 인지할 수 없음
- 코멘트 버튼에 불필요한 텍스트까지 읽어줌: “코멘트 버튼, 흐리게 표시됨, 버튼, 끝, 메인, 끝, 메인”
- 이미지에 적절한 alt 설명이 붙여져 있지 않음
- 스크린 리더기가 토스트 알림을 읽어주지 않아, 현재 상태(코멘트가 잘 전송된건지)를 파악 어려움.

2. 키보드 이용자의 불편함
- 키보드 사용자가 모멘트 이미지를 확장해서 볼 때, 닫기 버튼이 없어서 이미지를 끌 방법이 없음
- 오늘의 모멘트, 오늘의 코멘트 페이지의 전송 버튼에 키보드 포커스가 되지 않아 키보드 이용자는 전송을 할 수가 없음

### 모멘트 접근성 체크리스트

- 스크린 리더기 사용자가 이미지, 아이콘의 역할을 인식하기 위해 적절한 정보를 기입했는가?(alt, label 등)
- 스크린 리더기, 키보드 사용자가 클릭해야하는 요소에 접근할 수 있는가?
- 스크린 리더기 사용자에게 불필요한 정보를 주고있진 않는가?
- 현재 상태나 변경사항을 스크린 리더기 사용자가 인지할 수 있는가?