### PR TITLE
[항공사 웹사이트의 컴포넌트 접근성 높이기] 에리얼(정예지) 미션 제출합니다. 

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "deploy": "npm run build && npx gh-pages -d dist"
   },
   "author": "woowacourse",
-  "homepage": "https://{username}.github.io/a11y-airline",
+  "homepage": "https://yeji0214.github.io/a11y-airline",
   "license": "MIT",
   "dependencies": {
     "react": "^18.3.1",

--- a/src/App.module.css
+++ b/src/App.module.css
@@ -40,3 +40,19 @@
   background-color: white;
   text-align: center;
 }
+
+.skipLink {
+  position: absolute;
+  top: -40px;
+  left: 0;
+  background: #000;
+  color: #fff;
+  padding: 8px 16px;
+  z-index: 100;
+  text-decoration: none;
+  transition: top 0.2s ease;
+}
+
+.skipLink:focus {
+  top: 0;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,24 +8,24 @@ function App() {
   return (
     <div className={styles.app}>
       <Navigation />
-      <div className={styles.header}>
+      <header className={styles.header}>
         <h1 className={`${styles.title} heading-1-text`}>A11Y AIRLINE</h1>
         <p className="body-text">
           A11Y AIRLINE은 고객 여러분의 안전하고 쾌적한 여행을 위해 최선을 다하고 있습니다.
         </p>
-      </div>
-      <div id="main-content" className={styles.main}>
-        <div className={styles.flightBooking}>
+      </header>
+      <main id="main-content" className={styles.main}>
+        <section className={styles.flightBooking}>
           <FlightBooking />
-        </div>
-        <div className={styles.travelSection}>
-          <h1 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h1>
+        </section>
+        <section className={styles.travelSection}>
+          <h2 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h2>
           <TravelSection />
-        </div>
-      </div>
-      <div className={styles.footer}>
+        </section>
+      </main>
+      <footer className={styles.footer}>
         <p className="body-text">&copy; A11Y AIRLINE</p>
-      </div>
+      </footer>
       {/* 추가 CHALLENGE: 모달 포커스 트랩 */}
       {/* <PromotionModal /> */}
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,9 @@ import TravelSection from './components/TravelSection';
 function App() {
   return (
     <div className={styles.app}>
+      <a href="#main-content" className={styles.skipLink}>
+        본문으로 바로가기
+      </a>
       <Navigation />
       <header className={styles.header}>
         <h1 className={`${styles.title} heading-1-text`}>A11Y AIRLINE</h1>

--- a/src/components/TravelSection.module.css
+++ b/src/components/TravelSection.module.css
@@ -19,6 +19,11 @@
   height: 246px;
 }
 
+.card a {
+  color: inherit;
+  text-decoration: none;
+}
+
 .cardActive {
   display: block;
 }

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -57,13 +57,18 @@ const TravelSection = () => {
 
   return (
     <div className={styles.travelSection}>
-      <span className="visually-hidden" role="status" aria-atomic="true">
+      <span className="visually-hidden" aria-live="polite" aria-atomic="true">
         {`${travelOptions.length}개의 여행 상품 중 ${currentIndex + 1}번째 상품: ${
           travelOptions[currentIndex].departure
         } - ${travelOptions[currentIndex].destination} ${
           travelOptions[currentIndex].type
         } ${travelOptions[currentIndex].price.toLocaleString()}원`}
       </span>
+
+      <span id="carousel-instruction" className="visually-hidden">
+        선택하면 예약 페이지로 이동합니다.
+      </span>
+
       <button
         className={`${styles.navButton} ${styles.navButtonPrev}`}
         onClick={prevTravel}
@@ -83,13 +88,7 @@ const TravelSection = () => {
                 target="_blank"
                 rel="noopener noreferrer"
                 className={styles.cardLink}
-                aria-label={`${travelOptions.length}개의 여행 상품 중 ${
-                  currentIndex + 1
-                }번째 상품: ${travelOptions[currentIndex].departure} - ${
-                  travelOptions[currentIndex].destination
-                } ${travelOptions[currentIndex].type} ${travelOptions[
-                  currentIndex
-                ].price.toLocaleString()}원. 선택하면 예약 페이지로 이동합니다.`}
+                aria-describedby="carousel-instruction"
               >
                 <img src={option.image} className={styles.cardImage} alt="캐러셀 이미지" />
                 <div className={styles.cardContent}>

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -71,44 +71,46 @@ const TravelSection = () => {
       <button
         className={`${styles.navButton} ${styles.navButtonPrev}`}
         onClick={prevTravel}
-        aria-label="이전 상품 버튼"
+        aria-label="이전 상품"
       >
-        <img src={chevronLeft} className={styles.navButtonIcon} />
+        <img src={chevronLeft} className={styles.navButtonIcon} alt="" aria-hidden="true" />
       </button>
       <div className={styles.carousel}>
-        {travelOptions.map((option, index) => (
-          <li
-            key={index}
-            className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
-            onClick={() => handleCardClick(option.link)}
-          >
-            <a
-              href={option.link}
-              target="_blank"
-              rel="noopener noreferrer"
-              className={styles.cardLink}
-              aria-label={`${travelOptions[currentIndex].departure} - ${travelOptions[currentIndex].destination}: 선택하면 예약 페이지로 이동합니다.`}
+        <ul>
+          {travelOptions.map((option, index) => (
+            <li
+              key={index}
+              className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
+              onClick={() => handleCardClick(option.link)}
             >
-              <img src={option.image} className={styles.cardImage} />
-              <div className={styles.cardContent}>
-                <p className={`${styles.cardTitle} heading-3-text`}>
-                  {option.departure} - {option.destination}
-                </p>
-                <p className={`${styles.cardType} body-text`}>{option.type}</p>
-                <p className={`${styles.cardPrice} body-text`}>
-                  KRW {option.price.toLocaleString()}
-                </p>
-              </div>
-            </a>
-          </li>
-        ))}
+              <a
+                href={option.link}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={styles.cardLink}
+                aria-label={`${travelOptions[currentIndex].departure} - ${travelOptions[currentIndex].destination}: 선택하면 예약 페이지로 이동합니다.`}
+              >
+                <img src={option.image} className={styles.cardImage} alt="캐러셀 이미지" />
+                <div className={styles.cardContent}>
+                  <p className={`${styles.cardTitle} heading-3-text`}>
+                    {option.departure} - {option.destination}
+                  </p>
+                  <p className={`${styles.cardType} body-text`}>{option.type}</p>
+                  <p className={`${styles.cardPrice} body-text`}>
+                    KRW {option.price.toLocaleString()}
+                  </p>
+                </div>
+              </a>
+            </li>
+          ))}
+        </ul>
       </div>
       <button
         className={`${styles.navButton} ${styles.navButtonNext}`}
         onClick={nextTravel}
-        aria-label="다음 상품 버튼"
+        aria-label="다음 상품"
       >
-        <img src={chevronRight} className={styles.navButtonIcon} />
+        <img src={chevronRight} className={styles.navButtonIcon} alt="" aria-hidden="true" />
       </button>
     </div>
   );

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -55,10 +55,6 @@ const TravelSection = () => {
     setCurrentIndex((prevIndex) => (prevIndex - 1 + travelOptions.length) % travelOptions.length);
   };
 
-  const handleCardClick = (link: string) => {
-    window.open(link, '_blank', 'noopener,noreferrer');
-  };
-
   return (
     <div className={styles.travelSection}>
       <span className="visually-hidden" role="status" aria-atomic="true">
@@ -81,7 +77,6 @@ const TravelSection = () => {
             <li
               key={index}
               className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
-              onClick={() => handleCardClick(option.link)}
             >
               <a
                 href={option.link}

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -88,7 +88,13 @@ const TravelSection = () => {
                 target="_blank"
                 rel="noopener noreferrer"
                 className={styles.cardLink}
-                aria-label={`${travelOptions[currentIndex].departure} - ${travelOptions[currentIndex].destination}: 선택하면 예약 페이지로 이동합니다.`}
+                aria-label={`${travelOptions.length}개의 여행 상품 중 ${
+                  currentIndex + 1
+                }번째 상품: ${travelOptions[currentIndex].departure} - ${
+                  travelOptions[currentIndex].destination
+                } ${travelOptions[currentIndex].type} ${travelOptions[
+                  currentIndex
+                ].price.toLocaleString()}원. 선택하면 예약 페이지로 이동합니다.`}
               >
                 <img src={option.image} className={styles.cardImage} alt="캐러셀 이미지" />
                 <div className={styles.cardContent}>

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -61,28 +61,53 @@ const TravelSection = () => {
 
   return (
     <div className={styles.travelSection}>
-      <button className={`${styles.navButton} ${styles.navButtonPrev}`} onClick={prevTravel}>
+      <span className="visually-hidden" role="status" aria-atomic="true">
+        {`${travelOptions.length}개의 여행 상품 중 ${currentIndex + 1}번째 상품: ${
+          travelOptions[currentIndex].departure
+        } - ${travelOptions[currentIndex].destination} ${
+          travelOptions[currentIndex].type
+        } ${travelOptions[currentIndex].price.toLocaleString()}원`}
+      </span>
+      <button
+        className={`${styles.navButton} ${styles.navButtonPrev}`}
+        onClick={prevTravel}
+        aria-label="이전 상품 버튼"
+      >
         <img src={chevronLeft} className={styles.navButtonIcon} />
       </button>
       <div className={styles.carousel}>
         {travelOptions.map((option, index) => (
-          <div
+          <li
             key={index}
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
             onClick={() => handleCardClick(option.link)}
           >
-            <img src={option.image} className={styles.cardImage} />
-            <div className={styles.cardContent}>
-              <p className={`${styles.cardTitle} heading-3-text`}>
-                {option.departure} - {option.destination}
-              </p>
-              <p className={`${styles.cardType} body-text`}>{option.type}</p>
-              <p className={`${styles.cardPrice} body-text`}>KRW {option.price.toLocaleString()}</p>
-            </div>
-          </div>
+            <a
+              href={option.link}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={styles.cardLink}
+              aria-label={`${travelOptions[currentIndex].departure} - ${travelOptions[currentIndex].destination}: 선택하면 예약 페이지로 이동합니다.`}
+            >
+              <img src={option.image} className={styles.cardImage} />
+              <div className={styles.cardContent}>
+                <p className={`${styles.cardTitle} heading-3-text`}>
+                  {option.departure} - {option.destination}
+                </p>
+                <p className={`${styles.cardType} body-text`}>{option.type}</p>
+                <p className={`${styles.cardPrice} body-text`}>
+                  KRW {option.price.toLocaleString()}
+                </p>
+              </div>
+            </a>
+          </li>
         ))}
       </div>
-      <button className={`${styles.navButton} ${styles.navButtonNext}`} onClick={nextTravel}>
+      <button
+        className={`${styles.navButton} ${styles.navButtonNext}`}
+        onClick={nextTravel}
+        aria-label="다음 상품 버튼"
+      >
         <img src={chevronRight} className={styles.navButtonIcon} />
       </button>
     </div>

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -90,7 +90,11 @@ const TravelSection = () => {
                 className={styles.cardLink}
                 aria-describedby="carousel-instruction"
               >
-                <img src={option.image} className={styles.cardImage} alt="캐러셀 이미지" />
+                <img
+                  src={option.image}
+                  className={styles.cardImage}
+                  alt={`${travelOptions[currentIndex].departure} - ${travelOptions[currentIndex].destination} 캐러셀 이미지`}
+                />
                 <div className={styles.cardContent}>
                   <p className={`${styles.cardTitle} heading-3-text`}>
                     {option.departure} - {option.destination}


### PR DESCRIPTION
안녕하세요 퐁쥬 !! 🍫 잠실에서 잘 지내고 계신가요 ?.?
곧 연휴니 조금만 더 힘내봅시당 🙃
접근성 미션 제출합니다 !

## 🔥 결과

- 배포한 페이지 접근 경로(GitHub Pages): [배포](https://yeji0214.github.io/a11y-airline/)
- 스크린 리더 화면 녹화 영상

https://github.com/user-attachments/assets/b9e5f685-dc11-4b16-b3b3-6912d3b5573d


- lighthouse

|before|after|
|--|--|
|<img width="1898" height="1099" alt="image" src="https://github.com/user-attachments/assets/b0582d2b-d8bc-4a1d-8382-e0e97a665dbe" />|<img width="1924" height="1090" alt="image" src="https://github.com/user-attachments/assets/5164574b-3e80-42a9-8e47-7b3f20343a65" />



## ✅ 개선 작업 목록

<!-- 각 요구 사항을 위해 어떤 부분을 고민/학습해보았고, 결과적으로 어떤 개선 작업을 진행했는지 적어주세요-->

**1 컴포넌트 접근성 개선 - 이미지 캐로셀**

- [x] 스크린 리더가 캐로셀의 전체 아이템 수를 읽을 수 있어야 합니다.
- [x] 스크린 리더가 이미지 캐로셀 내 각 아이템 정보를 읽을 수 있어야 합니다.
  - [x] 여행지, 좌석 유형, 가격 정보를 한번에 읽을 수 있어야 합니다.
  - [x] 이전/다음 아이템으로 이동하고 현재 보이는 아이템의 정보를 읽을 수 있어야 합니다.
- [x] 각 아이템을 선택하면 각각에 맞는 링크로 이동할 수 있어야 합니다.

**2 페이지 접근성 개선**

- [x] 페이지를 하나의 문서로 읽을 수 있어야 합니다.
  - [x] 페이지에 적절한 제목(title)을 제공하세요. 제목은 페이지의 주요 내용을 간결하게 설명해야 합니다.
  - [x] 페이지의 주요 영역을 시맨틱 태그를 사용해 명확히 구분해 주세요
  - [x] 헤딩을 논리적인 순서로 사용해 페이지 구조를 명확히 해주세요
- [x] 키보드 사용자를 위해 페이지 최상단에 '본문으로 바로가기' 링크를 제공해 반복되는 메뉴를 건너뛸 수 있게 해주세요

## 🧐 우리 팀의 접근성 체크리스트

<!--
우리 서비스에서 이런 부분의 접근성은 챙겨봐야겠다! 하는 체크리스트 v1을 만들고, 리뷰어와 의견을 나눠보세요
- 우리 팀 서비스에서 가장 중요하고 자주 사용되는 기능 플로우 1개를 선택하고 간단히 나열해 주세요 (예: 로그인 → 상품 검색 → 상품 선택 → 장바구니 추가 → 결제)
- 해당 플로우의 각 단계에 대해 다음 질문을 생각해 보세요.
  - 1. 화면을 볼 수 없는 사용자가 이 단계를 완료할 수 있는가?
  - 2. 이 단계에서 제공하는 정보나 지시 사항이 모든 사용자에게 명확한가?
- 질문에 대해 팀원들과 의견을 나눠본 것을 바탕으로, 우리 팀만의 접근성 체크리스트 v1을 만들고 리뷰어와 의견을 나눠보세요. (예: "모든 이미지에 적절한 대체 텍스트가 제공되는가?")
-->

### 아맞다에서 가장 중요하고 자주 사용되는 기능 플로우
로그인 - 이벤트 스페이스 선택 - 이벤트 전체 조회 - 이벤트 상세 조회 - 이벤트 참여

### 가장 먼저 개선할 접근성 리스트
#### 로그인
- header, nav 등 시맨틱 태그를 사용해 적절한 지시사항을 안내하기

#### 이벤트 스페이스 선택
- 내가 속한 이벤트 스페이스의 총 개수 중 현재 이벤트 스페이스가 몇 번째인지 및 이벤트 스페이스의 이름 안내하기

#### 이벤트 전체 조회
- 총 이벤트 개수 중 현재 이벤트가 몇 번째인지 안내하기
- 이벤트 제목 등 정보 읽어주기

#### 이벤트 상세 조회
- 이벤트에 대한 전체 정보 읽어주기 (제목, 설명, 장소, 마감 시간, 주최자, 사전 질문 등), 참여 현황 안내하기 (총 인원과 현재 신청 인원)

#### 이벤트 참여
- 신청하기 버튼 클릭 시 이벤트 참여가 가능하다는 안내 제공하기 & 신청이 완료된 뒤에 버튼을 클릭하면 신청 취소가 가능하다는 점 안내하기
- 신청 버튼 클릭 시 신청이 완료되었다고 안내하기, 완료되지 않았다면 에러 메시지 읽어주기
- 신청하기 버튼의 상태 읽어주기 (현재 신청 여부)