### PR TITLE
[항공사 웹사이트의 컴포넌트 접근성 높이기] 재오(권재영) 미션 제출합니다

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,15 +1,13 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>A11Y AIRLINE</title>
+  </head>
 
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>React App</title>
-</head>
-
-<body>
-  <div id="root"></div>
-  <script type="module" src="/src/main.tsx"></script>
-</body>
-
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "deploy": "npm run build && npx gh-pages -d dist"
   },
   "author": "woowacourse",
-  "homepage": "https://{username}.github.io/a11y-airline",
+  "homepage": "https://jaeyoung-kwon.github.io/a11y-airline",
   "license": "MIT",
   "dependencies": {
     "react": "^18.3.1",

--- a/src/App.module.css
+++ b/src/App.module.css
@@ -40,3 +40,18 @@
   background-color: white;
   text-align: center;
 }
+
+.skipLink {
+  position: absolute;
+  top: 0;
+  left: 0;
+  transform: translateY(-100%);
+  padding: 8px 12px;
+  background: #000;
+  color: #fff;
+  z-index: 1000;
+}
+
+.skipLink:focus {
+  transform: translateY(0);
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,13 +8,13 @@ function App() {
   return (
     <div className={styles.app}>
       <Navigation />
-      <div className={styles.header}>
+      <header className={styles.header}>
         <h1 className={`${styles.title} heading-1-text`}>A11Y AIRLINE</h1>
         <p className="body-text">
           A11Y AIRLINE은 고객 여러분의 안전하고 쾌적한 여행을 위해 최선을 다하고 있습니다.
         </p>
-      </div>
-      <div id="main-content" className={styles.main}>
+      </header>
+      <main id="main-content" className={styles.main}>
         <div className={styles.flightBooking}>
           <FlightBooking />
         </div>
@@ -22,12 +22,10 @@ function App() {
           <h1 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h1>
           <TravelSection />
         </div>
-      </div>
-      <div className={styles.footer}>
+      </main>
+      <footer className={styles.footer}>
         <p className="body-text">&copy; A11Y AIRLINE</p>
-      </div>
-      {/* 추가 CHALLENGE: 모달 포커스 트랩 */}
-      {/* <PromotionModal /> */}
+      </footer>
     </div>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,13 +15,13 @@ function App() {
         </p>
       </header>
       <main id="main-content" className={styles.main}>
-        <div className={styles.flightBooking}>
+        <section className={styles.flightBooking}>
           <FlightBooking />
-        </div>
-        <div className={styles.travelSection}>
-          <h1 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h1>
+        </section>
+        <section className={styles.travelSection}>
+          <h2 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h2>
           <TravelSection />
-        </div>
+        </section>
       </main>
       <footer className={styles.footer}>
         <p className="body-text">&copy; A11Y AIRLINE</p>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,10 @@ import TravelSection from './components/TravelSection';
 function App() {
   return (
     <div className={styles.app}>
+      <a href="#main-content" className={styles.skipLink}>
+        본문으로 바로가기
+      </a>
+
       <Navigation />
       <header className={styles.header}>
         <h1 className={`${styles.title} heading-1-text`}>A11Y AIRLINE</h1>

--- a/src/components/TravelSection.module.css
+++ b/src/components/TravelSection.module.css
@@ -39,6 +39,10 @@
   bottom: 0;
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.9) 26%, rgba(255, 255, 255, 0) 100%);
   padding: 24px 16px;
+
+  p {
+    text-align: left;
+  }
 }
 
 .cardTitle {

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -57,61 +57,54 @@ const TravelSection = () => {
 
   return (
     <section className={styles.travelSection} aria-label="여행 상품 캐러셀">
-      <ul
-        className={styles.carousel}
-        role="region"
-        aria-roledescription="carousel"
-        aria-label="여행 상품 목록"
-      >
-        <p role="status" aria-atomic="true" className="visually-hidden">
-          {`총 ${travelOptions.length}개의 상품 중, ${currentIndex + 1}번째 상품.`}
-        </p>
+      <p role="status" aria-atomic="true" className="visually-hidden" aria-live="polite">
+        {`총 ${travelOptions.length}개의 상품 중, ${currentIndex + 1}번째 상품.`}
+      </p>
+
+      <ul className={styles.carousel} aria-live="polite">
         {travelOptions.map((option, index) => (
           <li
             key={index}
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
             aria-hidden={index !== currentIndex}
           >
-            <article>
-              <a
-                href={option.link}
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label={`${option.departure} 출발 ${option.destination} 도착. ${
-                  option.type
-                }. 가격 ${option.price.toLocaleString()}원. 선택하면 예약 페이지로 이동합니다.`}
-              >
-                <img src={option.image} className={styles.cardImage} alt="" />
-                <div className={styles.cardContent}>
-                  <h3 className={`${styles.cardTitle} heading-3-text`}>
-                    {option.departure} - {option.destination}
-                  </h3>
-                  <p className={`${styles.cardType} body-text`}>{option.type}</p>
-                  <p className={`${styles.cardPrice} body-text`}>
-                    KRW {option.price.toLocaleString()}
-                  </p>
-                </div>
-              </a>
-            </article>
+            <a
+              href={option.link}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label={`${option.departure} 출발 ${option.destination} 도착. ${
+                option.type
+              }. 가격 ${option.price.toLocaleString()}원. 선택하면 예약 페이지로 이동합니다.`}
+            >
+              <img src={option.image} className={styles.cardImage} alt="" />
+              <div className={styles.cardContent} aria-hidden="true">
+                <h2 className={`${styles.cardTitle} heading-3-text`}>
+                  {option.departure} - {option.destination}
+                </h2>
+                <p className={`${styles.cardType} body-text`}>{option.type}</p>
+                <p className={`${styles.cardPrice} body-text`}>
+                  KRW {option.price.toLocaleString()}
+                </p>
+              </div>
+            </a>
           </li>
         ))}
       </ul>
-      <nav aria-label="여행 상품 이동 버튼">
-        <button
-          className={`${styles.navButton} ${styles.navButtonPrev}`}
-          onClick={prevTravel}
-          aria-label="이전 여행 상품"
-        >
-          <img src={chevronLeft} className={styles.navButtonIcon} alt="" aria-hidden="true" />
-        </button>
-        <button
-          className={`${styles.navButton} ${styles.navButtonNext}`}
-          onClick={nextTravel}
-          aria-label="다음 여행 상품"
-        >
-          <img src={chevronRight} className={styles.navButtonIcon} alt="" aria-hidden="true" />
-        </button>
-      </nav>
+
+      <button
+        className={`${styles.navButton} ${styles.navButtonPrev}`}
+        onClick={prevTravel}
+        aria-label="이전 여행 상품"
+      >
+        <img src={chevronLeft} className={styles.navButtonIcon} alt="" aria-hidden="true" />
+      </button>
+      <button
+        className={`${styles.navButton} ${styles.navButtonNext}`}
+        onClick={nextTravel}
+        aria-label="다음 여행 상품"
+      >
+        <img src={chevronRight} className={styles.navButtonIcon} alt="" aria-hidden="true" />
+      </button>
     </section>
   );
 };

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -57,7 +57,7 @@ const TravelSection = () => {
 
   return (
     <section className={styles.travelSection} aria-label="여행 상품 캐러셀">
-      <p role="status" aria-atomic="true" className="visually-hidden" aria-live="polite">
+      <p role="status" className="visually-hidden">
         {`총 ${travelOptions.length}개의 상품 중, ${currentIndex + 1}번째 상품.`}
       </p>
 

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -61,15 +61,22 @@ const TravelSection = () => {
 
   return (
     <div className={styles.travelSection}>
-      <button className={`${styles.navButton} ${styles.navButtonPrev}`} onClick={prevTravel}>
-        <img src={chevronLeft} className={styles.navButtonIcon} />
+      <button
+        className={`${styles.navButton} ${styles.navButtonPrev}`}
+        onClick={prevTravel}
+        aria-label="이전 여행 상품"
+      >
+        <img src={chevronLeft} className={styles.navButtonIcon} aria-hidden="true" />
       </button>
       <div className={styles.carousel}>
         {travelOptions.map((option, index) => (
-          <div
+          <button
             key={index}
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
             onClick={() => handleCardClick(option.link)}
+            aria-label={`${option.departure} 출발 ${option.destination} 도착. ${
+              option.type
+            }. 가격 ${option.price.toLocaleString()}원. 선택하면 예약 페이지로 이동합니다.`}
           >
             <img src={option.image} className={styles.cardImage} />
             <div className={styles.cardContent}>
@@ -79,11 +86,15 @@ const TravelSection = () => {
               <p className={`${styles.cardType} body-text`}>{option.type}</p>
               <p className={`${styles.cardPrice} body-text`}>KRW {option.price.toLocaleString()}</p>
             </div>
-          </div>
+          </button>
         ))}
       </div>
-      <button className={`${styles.navButton} ${styles.navButtonNext}`} onClick={nextTravel}>
-        <img src={chevronRight} className={styles.navButtonIcon} />
+      <button
+        className={`${styles.navButton} ${styles.navButtonNext}`}
+        onClick={nextTravel}
+        aria-label="다음 여행 상품"
+      >
+        <img src={chevronRight} className={styles.navButtonIcon} aria-hidden="true" />
       </button>
     </div>
   );

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -61,6 +61,42 @@ const TravelSection = () => {
 
   return (
     <div className={styles.travelSection}>
+      <ul
+        className={styles.carousel}
+        role="region"
+        aria-roledescription="carousel"
+        aria-label="여행 상품 목록"
+        aria-live="polite"
+      >
+        <p role="status" aria-atomic="true" className="visually-hidden">
+          {`총 ${travelOptions.length}개의 상품 중, ${currentIndex + 1}번째 상품.`}
+        </p>
+        {travelOptions.map((option, index) => (
+          <li
+            key={index}
+            className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
+            aria-hidden={index !== currentIndex}
+          >
+            <button
+              onClick={() => handleCardClick(option.link)}
+              aria-label={`${option.departure} 출발 ${option.destination} 도착. ${
+                option.type
+              }. 가격 ${option.price.toLocaleString()}원. 선택하면 예약 페이지로 이동합니다.`}
+            >
+              <img src={option.image} className={styles.cardImage} />
+              <div className={styles.cardContent}>
+                <p className={`${styles.cardTitle} heading-3-text`}>
+                  {option.departure} - {option.destination}
+                </p>
+                <p className={`${styles.cardType} body-text`}>{option.type}</p>
+                <p className={`${styles.cardPrice} body-text`}>
+                  KRW {option.price.toLocaleString()}
+                </p>
+              </div>
+            </button>
+          </li>
+        ))}
+      </ul>
       <button
         className={`${styles.navButton} ${styles.navButtonPrev}`}
         onClick={prevTravel}
@@ -68,27 +104,6 @@ const TravelSection = () => {
       >
         <img src={chevronLeft} className={styles.navButtonIcon} aria-hidden="true" />
       </button>
-      <div className={styles.carousel}>
-        {travelOptions.map((option, index) => (
-          <button
-            key={index}
-            className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
-            onClick={() => handleCardClick(option.link)}
-            aria-label={`${option.departure} 출발 ${option.destination} 도착. ${
-              option.type
-            }. 가격 ${option.price.toLocaleString()}원. 선택하면 예약 페이지로 이동합니다.`}
-          >
-            <img src={option.image} className={styles.cardImage} />
-            <div className={styles.cardContent}>
-              <p className={`${styles.cardTitle} heading-3-text`}>
-                {option.departure} - {option.destination}
-              </p>
-              <p className={`${styles.cardType} body-text`}>{option.type}</p>
-              <p className={`${styles.cardPrice} body-text`}>KRW {option.price.toLocaleString()}</p>
-            </div>
-          </button>
-        ))}
-      </div>
       <button
         className={`${styles.navButton} ${styles.navButtonNext}`}
         onClick={nextTravel}

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -56,7 +56,7 @@ const TravelSection = () => {
   };
 
   return (
-    <section className={styles.travelSection} aria-label="여행 상품 캐러셀">
+    <div className={styles.travelSection} aria-label="여행 상품 캐러셀">
       <p role="status" className="visually-hidden">
         {`총 ${travelOptions.length}개의 상품 중, ${currentIndex + 1}번째 상품.`}
       </p>
@@ -78,9 +78,9 @@ const TravelSection = () => {
             >
               <img src={option.image} className={styles.cardImage} alt="" />
               <div className={styles.cardContent} aria-hidden="true">
-                <h2 className={`${styles.cardTitle} heading-3-text`}>
+                <h3 className={`${styles.cardTitle} heading-3-text`}>
                   {option.departure} - {option.destination}
-                </h2>
+                </h3>
                 <p className={`${styles.cardType} body-text`}>{option.type}</p>
                 <p className={`${styles.cardPrice} body-text`}>
                   KRW {option.price.toLocaleString()}
@@ -105,7 +105,7 @@ const TravelSection = () => {
       >
         <img src={chevronRight} className={styles.navButtonIcon} alt="" aria-hidden="true" />
       </button>
-    </section>
+    </div>
   );
 };
 

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -55,18 +55,13 @@ const TravelSection = () => {
     setCurrentIndex((prevIndex) => (prevIndex - 1 + travelOptions.length) % travelOptions.length);
   };
 
-  const handleCardClick = (link: string) => {
-    window.open(link, '_blank', 'noopener,noreferrer');
-  };
-
   return (
-    <div className={styles.travelSection}>
+    <section className={styles.travelSection} aria-label="여행 상품 캐러셀">
       <ul
         className={styles.carousel}
         role="region"
         aria-roledescription="carousel"
         aria-label="여행 상품 목록"
-        aria-live="polite"
       >
         <p role="status" aria-atomic="true" className="visually-hidden">
           {`총 ${travelOptions.length}개의 상품 중, ${currentIndex + 1}번째 상품.`}
@@ -77,41 +72,47 @@ const TravelSection = () => {
             className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
             aria-hidden={index !== currentIndex}
           >
-            <button
-              onClick={() => handleCardClick(option.link)}
-              aria-label={`${option.departure} 출발 ${option.destination} 도착. ${
-                option.type
-              }. 가격 ${option.price.toLocaleString()}원. 선택하면 예약 페이지로 이동합니다.`}
-            >
-              <img src={option.image} className={styles.cardImage} />
-              <div className={styles.cardContent}>
-                <p className={`${styles.cardTitle} heading-3-text`}>
-                  {option.departure} - {option.destination}
-                </p>
-                <p className={`${styles.cardType} body-text`}>{option.type}</p>
-                <p className={`${styles.cardPrice} body-text`}>
-                  KRW {option.price.toLocaleString()}
-                </p>
-              </div>
-            </button>
+            <article>
+              <a
+                href={option.link}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={`${option.departure} 출발 ${option.destination} 도착. ${
+                  option.type
+                }. 가격 ${option.price.toLocaleString()}원. 선택하면 예약 페이지로 이동합니다.`}
+              >
+                <img src={option.image} className={styles.cardImage} alt="" />
+                <div className={styles.cardContent}>
+                  <h3 className={`${styles.cardTitle} heading-3-text`}>
+                    {option.departure} - {option.destination}
+                  </h3>
+                  <p className={`${styles.cardType} body-text`}>{option.type}</p>
+                  <p className={`${styles.cardPrice} body-text`}>
+                    KRW {option.price.toLocaleString()}
+                  </p>
+                </div>
+              </a>
+            </article>
           </li>
         ))}
       </ul>
-      <button
-        className={`${styles.navButton} ${styles.navButtonPrev}`}
-        onClick={prevTravel}
-        aria-label="이전 여행 상품"
-      >
-        <img src={chevronLeft} className={styles.navButtonIcon} aria-hidden="true" />
-      </button>
-      <button
-        className={`${styles.navButton} ${styles.navButtonNext}`}
-        onClick={nextTravel}
-        aria-label="다음 여행 상품"
-      >
-        <img src={chevronRight} className={styles.navButtonIcon} aria-hidden="true" />
-      </button>
-    </div>
+      <nav aria-label="여행 상품 이동 버튼">
+        <button
+          className={`${styles.navButton} ${styles.navButtonPrev}`}
+          onClick={prevTravel}
+          aria-label="이전 여행 상품"
+        >
+          <img src={chevronLeft} className={styles.navButtonIcon} alt="" aria-hidden="true" />
+        </button>
+        <button
+          className={`${styles.navButton} ${styles.navButtonNext}`}
+          onClick={nextTravel}
+          aria-label="다음 여행 상품"
+        >
+          <img src={chevronRight} className={styles.navButtonIcon} alt="" aria-hidden="true" />
+        </button>
+      </nav>
+    </section>
   );
 };
 

--- a/src/index.css
+++ b/src/index.css
@@ -117,3 +117,8 @@ body {
   font-family: Arial, sans-serif;
   background-color: #f5f5f5;
 }
+
+a {
+  text-decoration: none;
+  color: inherit;
+}


### PR DESCRIPTION
안녕하세요 기린!!! 🙇‍♂️ 이렇게 만나뵙게 되어 반갑습니다 ㅎㅎ
이번 미션 잘 부탁드립니다!!

## 🔥 결과

<!-- 개선 작업 후 모바일 낭독기를 사용해서 미션 페이지를 읽어보세요 -->

- 배포한 페이지 접근 경로(GitHub Pages): https://jaeyoung-kwon.github.io/a11y-airline/
- 스크린 리더 화면 녹화 영상 (before / after):
  - [before]
https://github.com/user-attachments/assets/19edcc74-4e43-4647-8746-6c8c2e858573
  - [after]
https://github.com/user-attachments/assets/ffccc872-a5f6-4292-9a26-cce569258946




## ✅ 개선 작업 목록

<!-- 각 요구 사항을 위해 어떤 부분을 고민/학습해보았고, 결과적으로 어떤 개선 작업을 진행했는지 적어주세요-->

**1 컴포넌트 접근성 개선 - 이미지 캐로셀**

- [x] 스크린 리더가 캐로셀의 전체 아이템 수를 읽을 수 있어야 합니다.
- [x] 스크린 리더가 이미지 캐로셀 내 각 아이템 정보를 읽을 수 있어야 합니다.
  - [x] 여행지, 좌석 유형, 가격 정보를 한번에 읽을 수 있어야 합니다.
  - [x] 이전/다음 아이템으로 이동하고 현재 보이는 아이템의 정보를 읽을 수 있어야 합니다.
- [x] 각 아이템을 선택하면 각각에 맞는 링크로 이동할 수 있어야 합니다.

**2 페이지 접근성 개선**

- [x] 페이지를 하나의 문서로 읽을 수 있어야 합니다.
  - [x] 페이지에 적절한 제목(title)을 제공하세요. 제목은 페이지의 주요 내용을 간결하게 설명해야 합니다.
  - [x] 페이지의 주요 영역을 시맨틱 태그를 사용해 명확히 구분해 주세요
  - [x] 헤딩을 논리적인 순서로 사용해 페이지 구조를 명확히 해주세요
- [x] 키보드 사용자를 위해 페이지 최상단에 '본문으로 바로가기' 링크를 제공해 반복되는 메뉴를 건너뛸 수 있게 해주세요

## 🧐 우리 팀의 접근성 체크리스트

<!--
우리 서비스에서 이런 부분의 접근성은 챙겨봐야겠다! 하는 체크리스트 v1을 만들고, 리뷰어와 의견을 나눠보세요
- 우리 팀 서비스에서 가장 중요하고 자주 사용되는 기능 플로우 1개를 선택하고 간단히 나열해 주세요 (예: 로그인 → 상품 검색 → 상품 선택 → 장바구니 추가 → 결제)
- 해당 플로우의 각 단계에 대해 다음 질문을 생각해 보세요.
  - 1. 화면을 볼 수 없는 사용자가 이 단계를 완료할 수 있는가?
  - 2. 이 단계에서 제공하는 정보나 지시 사항이 모든 사용자에게 명확한가?
- 질문에 대해 팀원들과 의견을 나눠본 것을 바탕으로, 우리 팀만의 접근성 체크리스트 v1을 만들고 리뷰어와 의견을 나눠보세요. (예: "모든 이미지에 적절한 대체 텍스트가 제공되는가?")
-->

저희 봄봄 서비스의 핵심 플로우는
**‘오늘의 뉴스레터 → 읽기 현황 확인 → 오늘의 뉴스레터 리스트 확인 → 뉴스레터 읽기 페이지로 이동 → 뉴스레터 읽기’**입니다.

매일 ‘오늘의 뉴스레터’에 새로운 뉴스레터가 도착하고, 사용자는 그날 어떤 뉴스레터가 왔는지를 한눈에 확인한 뒤 읽고 싶은 뉴스레터를 선택해 읽는 것이 서비스 이용의 핵심 경험입니다.

하지만 현재 스크린 리더(보이스오버)로 테스트한 결과, 이 과정의 정보가 한 번에 전달되지 않거나, 불명확하게 읽히는 문제가 확인되었습니다.
이를 개선해 시각장애인 사용자도 오늘의 뉴스레터를 한눈에 파악하고 자연스럽게 읽을 수 있도록 접근성을 높이는 것이 필요하다고 생각합니다.

[봄봄 홈페이지 링크](www.bombom.news)

- [ ] 시멘틱 태그 적용: 주요 영역을 `<header>`, `<main>`, `<section>`, `<nav>` 등으로 구분해 논리적 구조 제공
- [ ] 이미지 대체 텍스트 추가: 캐릭터·로고·아이콘 등에 의미 있는 alt 또는 aria-label 부여
- [ ] 뉴스레터 목록 구조화: 뉴스레터 리스트를 `<ul>·<li>`로 구성하고, 각 항목의 제목을 링크(`<a>`)로 제공
- [ ] 상태 변화 읽기 처리: 진행률·출석 완료 등 동적 변화 요소에 aria-live="polite" 적용
- [ ] 버튼 역할 명시: 주간 목표 수정 아이콘, 출석 버튼 등 클릭 가능한 요소에 role="button" 및 aria-label 추가
- [ ] 하단 탭 내비게이션 개선: 현재 선택된 탭에 aria-current="page" 적용, 아이콘 버튼에 텍스트 라벨 제공
- [ ] 읽기 순서 정리: 화면의 시각적 순서와 DOM 순서를 일치시켜 자연스러운 낭독 흐름 유지

