### PR TITLE
[항공사 웹사이트의 컴포넌트 접근성 높이기] 세오(진솔) 미션 제출합니다. 

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,15 +1,13 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>A11Y AIRLINE</title>
+  </head>
 
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>React App</title>
-</head>
-
-<body>
-  <div id="root"></div>
-  <script type="module" src="/src/main.tsx"></script>
-</body>
-
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "deploy": "npm run build && npx gh-pages -d dist"
   },
   "author": "woowacourse",
-  "homepage": "https://{username}.github.io/a11y-airline",
+  "homepage": "https://jin123457.github.io/a11y-airline",
   "license": "MIT",
   "dependencies": {
     "react": "^18.3.1",

--- a/src/App.module.css
+++ b/src/App.module.css
@@ -9,6 +9,24 @@
   margin: 0 auto;
 }
 
+.skipLink {
+  position: absolute;
+  top: -40px;
+  left: 6px;
+  background: #000;
+  color: #fff;
+  padding: 8px;
+  z-index: 1000;
+  text-decoration: none;
+  border-radius: 4px;
+  font-weight: bold;
+  transition: top 0.3s;
+}
+
+.skipLink:focus {
+  top: 6px;
+}
+
 .header {
   padding: 48px 24px 24px 24px;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,7 @@ function App() {
           <FlightBooking />
         </div>
         <div className={styles.travelSection}>
-          <h1 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h1>
+          <h2 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h2>
           <TravelSection />
         </div>
       </main>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,13 +8,13 @@ function App() {
   return (
     <div className={styles.app}>
       <Navigation />
-      <div className={styles.header}>
+      <header className={styles.header}>
         <h1 className={`${styles.title} heading-1-text`}>A11Y AIRLINE</h1>
         <p className="body-text">
           A11Y AIRLINE은 고객 여러분의 안전하고 쾌적한 여행을 위해 최선을 다하고 있습니다.
         </p>
-      </div>
-      <div id="main-content" className={styles.main}>
+      </header>
+      <main id="main-content" className={styles.main}>
         <div className={styles.flightBooking}>
           <FlightBooking />
         </div>
@@ -22,10 +22,10 @@ function App() {
           <h1 className={`${styles.travelTitle} heading-2-text`}>지금 떠나기 좋은 여행</h1>
           <TravelSection />
         </div>
-      </div>
-      <div className={styles.footer}>
+      </main>
+      <footer className={styles.footer}>
         <p className="body-text">&copy; A11Y AIRLINE</p>
-      </div>
+      </footer>
       {/* 추가 CHALLENGE: 모달 포커스 트랩 */}
       {/* <PromotionModal /> */}
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,11 +2,14 @@ import styles from './App.module.css';
 import Navigation from './components/Navigation';
 import FlightBooking from './components/FlightBooking';
 import TravelSection from './components/TravelSection';
-// import PromotionModal from './components/PromotionModal';
+import PromotionModal from './components/PromotionModal';
 
 function App() {
   return (
     <div className={styles.app}>
+      <a href="#main-content" className={styles.skipLink}>
+        메인 콘텐츠로 이동
+      </a>
       <Navigation />
       <header className={styles.header}>
         <h1 className={`${styles.title} heading-1-text`}>A11Y AIRLINE</h1>
@@ -27,7 +30,7 @@ function App() {
         <p className="body-text">&copy; A11Y AIRLINE</p>
       </footer>
       {/* 추가 CHALLENGE: 모달 포커스 트랩 */}
-      {/* <PromotionModal /> */}
+      <PromotionModal />
     </div>
   );
 }

--- a/src/components/FlightBooking.module.css
+++ b/src/components/FlightBooking.module.css
@@ -14,6 +14,8 @@
   position: relative;
   margin-left: 5px;
   cursor: pointer;
+  border: none;
+  background-color: transparent;
 }
 
 .helpIcon {
@@ -77,7 +79,6 @@
 .counter span {
   font-size: 18px;
   text-align: center;
-  font-size: 18px;
   font-style: normal;
   font-weight: 500;
   line-height: normal;

--- a/src/components/FlightBooking.tsx
+++ b/src/components/FlightBooking.tsx
@@ -40,21 +40,46 @@ const FlightBooking = () => {
       <div className={styles.passengerCount}>
         <div className={styles.passengerLabel}>
           <span className="body-text">성인</span>
-          <div
+          <button
+            type="button"
             className={styles.helpIconWrapper}
             onMouseEnter={() => setShowTooltip(true)}
             onMouseLeave={() => setShowTooltip(false)}
+            onFocus={() => setShowTooltip(true)}
+            onBlur={() => setShowTooltip(false)}
+            aria-describedby={showTooltip ? 'help-tooltip' : undefined}
+            aria-label="승객 수 제한 도움말"
           >
-            <img src={helpIcon} alt="도움말" className={styles.helpIcon} />
-            {showTooltip && <div className={styles.tooltip}>최대 3명까지 예약할 수 있습니다</div>}
-          </div>
+            <img src={helpIcon} alt="" className={styles.helpIcon} />
+            {showTooltip && (
+              <div id="help-tooltip" className={styles.tooltip} role="tooltip">
+                최대 3명까지 예약할 수 있습니다
+              </div>
+            )}
+          </button>
         </div>
         <div className={styles.counter}>
-          <button className="button-text" onClick={decrementCount} aria-label="성인 승객 감소">
+          <button
+            type="button"
+            className="button-text"
+            onClick={decrementCount}
+            aria-label="성인 승객 감소"
+            disabled={adultCount === MIN_PASSENGERS}
+          >
             <img src={minus} alt="" />
           </button>
-          <span aria-live="polite">{adultCount}</span>
-          <button className="button-text" onClick={incrementCount} aria-label="성인 승객 증가">
+          <output aria-live="polite">
+            <span className="visually-hidden">현재 성인 승객 수: </span>
+            {adultCount}
+            <span className="visually-hidden">명</span>
+          </output>
+          <button
+            type="button"
+            className="button-text"
+            onClick={incrementCount}
+            aria-label="성인 승객 증가"
+            disabled={adultCount === MAX_PASSENGERS}
+          >
             <img src={plus} alt="" />
           </button>
         </div>
@@ -64,7 +89,9 @@ const FlightBooking = () => {
           {statusMessage}
         </div>
       )}
-      <button className={styles.searchButton}>항공편 검색</button>
+      <button type="button" className={styles.searchButton}>
+        항공편 검색
+      </button>
     </div>
   );
 };

--- a/src/components/FlightBooking.tsx
+++ b/src/components/FlightBooking.tsx
@@ -68,11 +68,7 @@ const FlightBooking = () => {
           >
             <img src={minus} alt="" />
           </button>
-          <output aria-live="polite">
-            <span className="visually-hidden">현재 성인 승객 수: </span>
-            {adultCount}
-            <span className="visually-hidden">명</span>
-          </output>
+          <output aria-live="polite">{adultCount}</output>
           <button
             type="button"
             className="button-text"

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -44,12 +44,23 @@ const Navigation = () => {
     setIsNavOpen((prev) => !prev);
   };
 
-  const renderNavItems = (items: NavItem[]) => (
-    <ul className={styles.navList}>
-      {items.map((item, index) => (
-        <li key={index} className={styles.navItem}>
-          <a href={item.link}>{item.title}</a>
-          {item.subItems && renderNavItems(item.subItems)}
+  const renderNavItems = (items: NavItem[], isSubMenu: boolean = false) => (
+    <ul className={styles.navList} role={isSubMenu ? 'group' : 'menubar'}>
+      {items.map((item) => (
+        <li key={item.title} className={styles.navItem} role="none">
+          <a
+            href={item.link}
+            role="menuitem"
+            aria-haspopup={item.subItems ? 'true' : undefined}
+            aria-expanded={item.subItems ? 'false' : undefined}
+          >
+            {item.title}
+          </a>
+          {item.subItems && (
+            <div role="menu" aria-label={`${item.title} 하위 메뉴`}>
+              {renderNavItems(item.subItems, true)}
+            </div>
+          )}
         </li>
       ))}
     </ul>
@@ -57,10 +68,21 @@ const Navigation = () => {
 
   return (
     <>
-      <button className={styles.navToggle} onClick={toggleNav}>
+      <button
+        type="button"
+        className={styles.navToggle}
+        onClick={toggleNav}
+        aria-expanded={isNavOpen}
+        aria-controls="main-nav"
+        aria-label="메인 네비게이션 토글"
+      >
         {isNavOpen ? '닫기' : '메뉴'}
       </button>
-      <nav id="main-nav" className={`${styles.mainNav} ${isNavOpen ? styles.mainNavActive : ''}`}>
+      <nav
+        id="main-nav"
+        className={`${styles.mainNav} ${isNavOpen ? styles.mainNavActive : ''}`}
+        aria-label="메인 네비게이션"
+      >
         {renderNavItems(navItems)}
       </nav>
     </>

--- a/src/components/PromotionModal.tsx
+++ b/src/components/PromotionModal.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
+import { useFocusTrap } from '../hooks/useFocusTrap';
 
 import close from '../assets/close.svg';
 
@@ -7,9 +8,15 @@ import styles from './PromotionModal.module.css';
 const PromotionModal = () => {
   const [isOpen, setIsOpen] = useState(true);
 
-  const closeModal = () => {
+  const closeModal = useCallback(() => {
     setIsOpen(false);
-  };
+  }, []);
+
+  const modalRef = useFocusTrap<HTMLDivElement>({
+    isActive: isOpen,
+    onClose: closeModal,
+    restoreFocus: true
+  });
 
   if (!isOpen) {
     return null;
@@ -17,17 +24,38 @@ const PromotionModal = () => {
 
   return (
     <div className={styles.modal}>
-      <div className={styles.modalBackdrop} onClick={closeModal}></div>
-      <div className={styles.modalContainer}>
+      <button
+        type="button"
+        className={styles.modalBackdrop}
+        onClick={closeModal}
+        aria-label="모달 닫기"
+      />
+      <div
+        ref={modalRef}
+        className={styles.modalContainer}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="modal-title"
+        aria-describedby="modal-description"
+      >
         <div className={styles.modalContent}>
-          <h2 className={`${styles.modalTitle} heading-2-text`}>여행할 땐 A11Y AIRLINE 앱</h2>
-          <p className={`${styles.modalDescription} body-text`}>
+          <h2 id="modal-title" className={`${styles.modalTitle} heading-2-text`}>
+            여행할 땐 A11Y AIRLINE 앱
+          </h2>
+          <p id="modal-description" className={`${styles.modalDescription} body-text`}>
             체크인, 탑승권 저장, 수하물 알림까지
             <br />- 앱으로 더욱 편하게 여행하세요!
           </p>
-          <button className={`${styles.modalActionButton} button-text`}>앱에서 열기</button>
-          <button className={`${styles.modalCloseButton} heading-2-text`} onClick={closeModal}>
-            <img src={close} />
+          <button type="button" className={`${styles.modalActionButton} button-text`}>
+            앱에서 열기
+          </button>
+          <button
+            type="button"
+            className={`${styles.modalCloseButton} heading-2-text`}
+            onClick={closeModal}
+            aria-label="모달 닫기"
+          >
+            <img src={close} alt="" />
           </button>
         </div>
       </div>

--- a/src/components/TravelSection.module.css
+++ b/src/components/TravelSection.module.css
@@ -86,3 +86,15 @@
   width: 24px;
   height: 24px;
 }
+
+.visuallyHidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -46,7 +46,7 @@ const travelOptions: TravelOption[] = [
 
 const TravelSection = () => {
   const [currentIndex, setCurrentIndex] = useState(0);
-  const liveMessage = `세계 여행지 상품 중 ${currentIndex + 1}번째 상품`;
+  const liveMessage = `${travelOptions.length}개 세계 여행 상품 중 ${currentIndex + 1}번째 상품`;
 
   const nextTravel = () => {
     setCurrentIndex((prevIndex) => (prevIndex + 1) % travelOptions.length);
@@ -61,23 +61,26 @@ const TravelSection = () => {
   };
 
   return (
-    <section>
-      <p aria-live="polite" className={`${styles.visuallyHidden}`}>
+    <section aria-labelledby="travel-section-title">
+      <div aria-live="polite" aria-atomic="true" className="visually-hidden">
         {liveMessage}
-      </p>
+      </div>
       <div className={styles.travelSection}>
-        <div className={styles.carousel}>
+        <div className={styles.carousel} id="travel-carousel">
           {travelOptions.map((option, index) => (
             <button
               type="button"
-              key={index}
+              key={`${option.departure}-${option.destination}`}
               className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
               onClick={() => handleCardClick(option.link)}
               aria-live="polite"
-              aria-label={`${liveMessage} ${option.departure}에서 ${option.destination}까지, ${
+              aria-label={`${option.departure}에서 ${option.destination}까지, ${
                 option.type
-              }, 가격 KRW ${option.price.toLocaleString()} 클릭하시면 예약페이지로 이동합니다.`}
-              aria-roledescription="여행 상품"
+              }, 가격 KRW ${option.price.toLocaleString(
+                'ko-KR'
+              )} 클릭하시면 예약페이지로 이동합니다.`}
+              aria-current={index === currentIndex ? 'true' : undefined}
+              tabIndex={index === currentIndex ? 0 : -1}
             >
               <img src={option.image} className={styles.cardImage} alt="" />
               <div className={styles.cardContent}>
@@ -96,17 +99,19 @@ const TravelSection = () => {
           type="button"
           className={`${styles.navButton} ${styles.navButtonPrev}`}
           onClick={prevTravel}
-          aria-controls="carousel"
+          aria-controls="travel-carousel"
+          aria-label="이전 여행 상품"
         >
-          <img src={chevronLeft} className={styles.navButtonIcon} alt="이전 여행지 상품" />
+          <img src={chevronLeft} className={styles.navButtonIcon} alt="" />
         </button>
         <button
           type="button"
           className={`${styles.navButton} ${styles.navButtonNext}`}
           onClick={nextTravel}
-          aria-controls="carousel"
+          aria-controls="travel-carousel"
+          aria-label="다음 여행 상품"
         >
-          <img src={chevronRight} className={styles.navButtonIcon} alt="다음 여행지 상품" />
+          <img src={chevronRight} className={styles.navButtonIcon} alt="" />
         </button>
       </div>
     </section>

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -46,6 +46,7 @@ const travelOptions: TravelOption[] = [
 
 const TravelSection = () => {
   const [currentIndex, setCurrentIndex] = useState(0);
+  const liveMessage = `세계 여행지 상품 중 ${currentIndex + 1}번째 상품`;
 
   const nextTravel = () => {
     setCurrentIndex((prevIndex) => (prevIndex + 1) % travelOptions.length);
@@ -60,32 +61,55 @@ const TravelSection = () => {
   };
 
   return (
-    <div className={styles.travelSection}>
-      <button className={`${styles.navButton} ${styles.navButtonPrev}`} onClick={prevTravel}>
-        <img src={chevronLeft} className={styles.navButtonIcon} />
-      </button>
-      <div className={styles.carousel}>
-        {travelOptions.map((option, index) => (
-          <div
-            key={index}
-            className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
-            onClick={() => handleCardClick(option.link)}
-          >
-            <img src={option.image} className={styles.cardImage} />
-            <div className={styles.cardContent}>
-              <p className={`${styles.cardTitle} heading-3-text`}>
-                {option.departure} - {option.destination}
-              </p>
-              <p className={`${styles.cardType} body-text`}>{option.type}</p>
-              <p className={`${styles.cardPrice} body-text`}>KRW {option.price.toLocaleString()}</p>
-            </div>
-          </div>
-        ))}
+    <section>
+      <p aria-live="polite" className={`${styles.visuallyHidden}`}>
+        {liveMessage}
+      </p>
+      <div className={styles.travelSection}>
+        <div className={styles.carousel}>
+          {travelOptions.map((option, index) => (
+            <button
+              type="button"
+              key={index}
+              className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
+              onClick={() => handleCardClick(option.link)}
+              aria-live="polite"
+              aria-label={`${liveMessage} ${option.departure}에서 ${option.destination}까지, ${
+                option.type
+              }, 가격 KRW ${option.price.toLocaleString()} 클릭하시면 예약페이지로 이동합니다.`}
+              aria-roledescription="여행 상품"
+            >
+              <img src={option.image} className={styles.cardImage} alt="" />
+              <div className={styles.cardContent}>
+                <p className={`${styles.cardTitle} heading-3-text`}>
+                  {option.departure} - {option.destination}
+                </p>
+                <p className={`${styles.cardType} body-text`}>{option.type}</p>
+                <p className={`${styles.cardPrice} body-text`}>
+                  KRW {option.price.toLocaleString()}
+                </p>
+              </div>
+            </button>
+          ))}
+        </div>
+        <button
+          type="button"
+          className={`${styles.navButton} ${styles.navButtonPrev}`}
+          onClick={prevTravel}
+          aria-controls="carousel"
+        >
+          <img src={chevronLeft} className={styles.navButtonIcon} alt="이전 여행지 상품" />
+        </button>
+        <button
+          type="button"
+          className={`${styles.navButton} ${styles.navButtonNext}`}
+          onClick={nextTravel}
+          aria-controls="carousel"
+        >
+          <img src={chevronRight} className={styles.navButtonIcon} alt="다음 여행지 상품" />
+        </button>
       </div>
-      <button className={`${styles.navButton} ${styles.navButtonNext}`} onClick={nextTravel}>
-        <img src={chevronRight} className={styles.navButtonIcon} />
-      </button>
-    </div>
+    </section>
   );
 };
 

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -46,7 +46,7 @@ const travelOptions: TravelOption[] = [
 
 const TravelSection = () => {
   const [currentIndex, setCurrentIndex] = useState(0);
-  const liveMessage = `${travelOptions.length}개 세계 여행 상품 중 ${currentIndex + 1}번째 상품`;
+  const liveMessage = `${travelOptions.length}개 여행 상품 중 ${currentIndex + 1}번째 상품`;
 
   const nextTravel = () => {
     setCurrentIndex((prevIndex) => (prevIndex + 1) % travelOptions.length);
@@ -71,6 +71,7 @@ const TravelSection = () => {
             <li key={`${option.departure}-${option.destination}`}>
               <button
                 type="button"
+                aria-live="polite"
                 className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
                 onClick={() => handleCardClick(option.link)}
                 aria-label={`${option.departure}에서 ${option.destination}까지, ${

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -62,16 +62,13 @@ const TravelSection = () => {
 
   return (
     <section aria-labelledby="travel-section-title">
-      <div aria-live="polite" aria-atomic="true" className="visually-hidden">
-        {liveMessage}
-      </div>
+      <output className="visually-hidden">{liveMessage}</output>
       <div className={styles.travelSection}>
         <ul className={styles.carousel} id="travel-carousel">
           {travelOptions.map((option, index) => (
             <li key={`${option.departure}-${option.destination}`}>
               <button
                 type="button"
-                aria-live="polite"
                 className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
                 onClick={() => handleCardClick(option.link)}
                 aria-label={`${option.departure}에서 ${option.destination}까지, ${

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -66,35 +66,35 @@ const TravelSection = () => {
         {liveMessage}
       </div>
       <div className={styles.travelSection}>
-        <div className={styles.carousel} id="travel-carousel">
+        <ul className={styles.carousel} id="travel-carousel">
           {travelOptions.map((option, index) => (
-            <button
-              type="button"
-              key={`${option.departure}-${option.destination}`}
-              className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
-              onClick={() => handleCardClick(option.link)}
-              aria-live="polite"
-              aria-label={`${option.departure}에서 ${option.destination}까지, ${
-                option.type
-              }, 가격 KRW ${option.price.toLocaleString(
-                'ko-KR'
-              )} 클릭하시면 예약페이지로 이동합니다.`}
-              aria-current={index === currentIndex ? 'true' : undefined}
-              tabIndex={index === currentIndex ? 0 : -1}
-            >
-              <img src={option.image} className={styles.cardImage} alt="" />
-              <div className={styles.cardContent}>
-                <p className={`${styles.cardTitle} heading-3-text`}>
-                  {option.departure} - {option.destination}
-                </p>
-                <p className={`${styles.cardType} body-text`}>{option.type}</p>
-                <p className={`${styles.cardPrice} body-text`}>
-                  KRW {option.price.toLocaleString()}
-                </p>
-              </div>
-            </button>
+            <li key={`${option.departure}-${option.destination}`}>
+              <button
+                type="button"
+                className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}
+                onClick={() => handleCardClick(option.link)}
+                aria-label={`${option.departure}에서 ${option.destination}까지, ${
+                  option.type
+                }, 가격 KRW ${option.price.toLocaleString(
+                  'ko-KR'
+                )} 클릭하시면 예약페이지로 이동합니다.`}
+                aria-current={index === currentIndex ? 'true' : undefined}
+                tabIndex={index === currentIndex ? 0 : -1}
+              >
+                <img src={option.image} className={styles.cardImage} alt="" />
+                <div className={styles.cardContent}>
+                  <p className={`${styles.cardTitle} heading-3-text`}>
+                    {option.departure} - {option.destination}
+                  </p>
+                  <p className={`${styles.cardType} body-text`}>{option.type}</p>
+                  <p className={`${styles.cardPrice} body-text`}>
+                    KRW {option.price.toLocaleString('ko-KR')}
+                  </p>
+                </div>
+              </button>
+            </li>
           ))}
-        </div>
+        </ul>
         <button
           type="button"
           className={`${styles.navButton} ${styles.navButtonPrev}`}

--- a/src/components/TravelSection.tsx
+++ b/src/components/TravelSection.tsx
@@ -66,7 +66,10 @@ const TravelSection = () => {
       <div className={styles.travelSection}>
         <ul className={styles.carousel} id="travel-carousel">
           {travelOptions.map((option, index) => (
-            <li key={`${option.departure}-${option.destination}`}>
+            <li
+              key={`${option.departure}-${option.destination}`}
+              aria-hidden={index !== currentIndex}
+            >
               <button
                 type="button"
                 className={`${styles.card} ${index === currentIndex ? styles.cardActive : ''}`}

--- a/src/hooks/useFocusTrap.ts
+++ b/src/hooks/useFocusTrap.ts
@@ -43,16 +43,12 @@ export const useFocusTrap = <T extends HTMLElement = HTMLElement>({
         const firstElement = focusableElements[0] as HTMLElement;
         const lastElement = focusableElements[focusableElements.length - 1] as HTMLElement;
 
-        if (event.shiftKey) {
-          if (document.activeElement === firstElement) {
-            lastElement.focus();
-            event.preventDefault();
-          }
-        } else {
-          if (document.activeElement === lastElement) {
-            firstElement.focus();
-            event.preventDefault();
-          }
+        if (event.shiftKey && document.activeElement === firstElement) {
+          lastElement.focus();
+          event.preventDefault();
+        } else if (!event.shiftKey && document.activeElement === lastElement) {
+          firstElement.focus();
+          event.preventDefault();
         }
       }
     },

--- a/src/hooks/useFocusTrap.ts
+++ b/src/hooks/useFocusTrap.ts
@@ -1,0 +1,83 @@
+import { useEffect, useRef, useCallback } from 'react';
+
+interface UseFocusTrapOptions {
+  isActive: boolean;
+  onClose?: () => void;
+  restoreFocus?: boolean;
+}
+
+export const useFocusTrap = <T extends HTMLElement = HTMLElement>({
+  isActive,
+  onClose,
+  restoreFocus = true
+}: UseFocusTrapOptions) => {
+  const containerRef = useRef<T>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  const focusFirstElement = useCallback(() => {
+    if (!containerRef.current) return;
+
+    const firstFocusableElement = containerRef.current.querySelector(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    ) as HTMLElement;
+
+    if (firstFocusableElement) {
+      firstFocusableElement.focus();
+    }
+  }, []);
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && onClose) {
+        onClose();
+        return;
+      }
+
+      if (event.key === 'Tab' && containerRef.current) {
+        const focusableElements = containerRef.current.querySelectorAll(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        );
+
+        if (focusableElements.length === 0) return;
+
+        const firstElement = focusableElements[0] as HTMLElement;
+        const lastElement = focusableElements[focusableElements.length - 1] as HTMLElement;
+
+        if (event.shiftKey) {
+          if (document.activeElement === firstElement) {
+            lastElement.focus();
+            event.preventDefault();
+          }
+        } else {
+          if (document.activeElement === lastElement) {
+            firstElement.focus();
+            event.preventDefault();
+          }
+        }
+      }
+    },
+    [onClose]
+  );
+
+  useEffect(() => {
+    if (isActive) {
+      if (restoreFocus) {
+        previousFocusRef.current = document.activeElement as HTMLElement;
+      }
+
+      setTimeout(focusFirstElement, 0);
+
+      document.addEventListener('keydown', handleKeyDown);
+
+      return () => {
+        document.removeEventListener('keydown', handleKeyDown);
+
+        if (restoreFocus && previousFocusRef.current) {
+          previousFocusRef.current.focus();
+        }
+      };
+    }
+  }, [isActive, handleKeyDown, focusFirstElement, restoreFocus]);
+
+  return containerRef;
+};

--- a/tsconfig.app.tsbuildinfo
+++ b/tsconfig.app.tsbuildinfo
@@ -1,0 +1,1 @@
+{"root":["./src/app.tsx","./src/image.d.ts","./src/main.tsx","./src/vite-env.d.ts","./src/components/flightbooking.tsx","./src/components/navigation.tsx","./src/components/promotionmodal.tsx","./src/components/travelsection.tsx"],"errors":true,"version":"5.8.3"}

--- a/tsconfig.node.tsbuildinfo
+++ b/tsconfig.node.tsbuildinfo
@@ -1,0 +1,1 @@
+{"root":["./vite.config.ts"],"errors":true,"version":"5.8.3"}


### PR DESCRIPTION
안녕하세요 카멜☕️
리뷰어와 리뷰이로 만나니 굉장히 색다른 느낌이네요..ㅎㅎ
잘 부탁드립니다!!🙇‍♂️🙇‍♂️

## 🔥 결과

<!-- 개선 작업 후 모바일 낭독기를 사용해서 미션 페이지를 읽어보세요 -->

- 배포한 페이지 접근 경로(GitHub Pages): [🛫세오의 항공사 웹사이트 보러가기](https://jin123457.github.io/a11y-airline/)
- 스크린 리더 화면 녹화 영상 (before / after) : 
**BEFORE**
<img width="517" height="476" alt="스크린샷 2025-09-30 오후 4 43 50" src="https://github.com/user-attachments/assets/598ad5ec-ab0f-4faa-98b2-5438dcfae9b6" />

**AFTER**
<img width="514" height="583" alt="스크린샷 2025-09-30 오전 5 26 17" src="https://github.com/user-attachments/assets/c7c81d1c-2c63-494f-b3ed-c49fcfe10ea5" />


[🎬 영상보러가기](https://www.notion.so/a11y-27ea9202b17980c7917ce267f2ecd043)


## ✅ 개선 작업 목록

<!-- 각 요구 사항을 위해 어떤 부분을 고민/학습해보았고, 결과적으로 어떤 개선 작업을 진행했는지 적어주세요-->

**1 컴포넌트 접근성 개선 - 이미지 캐로셀**

- [x] 스크린 리더가 캐로셀의 전체 아이템 수를 읽을 수 있어야 합니다.
- [x] 스크린 리더가 이미지 캐로셀 내 각 아이템 정보를 읽을 수 있어야 합니다.
  - [x] 여행지, 좌석 유형, 가격 정보를 한번에 읽을 수 있어야 합니다.
  - [x] 이전/다음 아이템으로 이동하고 현재 보이는 아이템의 정보를 읽을 수 있어야 합니다.
- [x] 각 아이템을 선택하면 각각에 맞는 링크로 이동할 수 있어야 합니다.

**2 페이지 접근성 개선**

- [x] 페이지를 하나의 문서로 읽을 수 있어야 합니다.
  - [x] 페이지에 적절한 제목(title)을 제공하세요. 제목은 페이지의 주요 내용을 간결하게 설명해야 합니다.
  - [x] 페이지의 주요 영역을 시맨틱 태그를 사용해 명확히 구분해 주세요
  - [x] 헤딩을 논리적인 순서로 사용해 페이지 구조를 명확히 해주세요
- [x] 키보드 사용자를 위해 페이지 최상단에 '본문으로 바로가기' 링크를 제공해 반복되는 메뉴를 건너뛸 수 있게 해주세요


## 적용한 점

- **App.module.css / App.tsx**
  - `.skipLink` 클래스를 활용해 키보드 사용자가 최상단에서 바로 본문(`main`)으로 이동할 수 있도록 처리 
  - `header`, `main`, `footer` 태그를 사용하여 페이지 구조를 명확히 구분

- **TravelSection.module.css / TravelSection.tsx**
  - `.visuallyHidden` 클래스를 만들어 스크린 리더 전용 텍스트를 지원, 캐로셀 안내 문구를 숨김 상태로 제공
  - 캐로셀 아이템은 `.cardActive`일 때만 표시되며, 나머지는 `display: none` 처리로 스크린 리더 인식에서 제외
  - 이전/다음 버튼(`.navButtonPrev`, `.navButtonNext`)을 제공해 키보드와 보조기술로도 이동 가능하도록 함

- **FlightBooking.module.css / FlightBooking.tsx**
  - `.helpIconWrapper`와 `.tooltip`을 통해 추가 설명을 제공, 시각적으로는 아이콘이지만 보조 텍스트가 함께 제공됨
  - 승객 수 조절 버튼(`.counter button`)은 포커스 가능하고 크기/대비가 확보되어 있어 접근성 보장

- **PromotionModal.module.css / PromotionModal.tsx**
  - `.modalBackdrop`과 `.modalCloseButton`을 구현하여 키보드로도 모달을 닫을 수 있게 지원
  - `.modalContainer`는 화면 중앙에 고정되어 있고, 포커스 이동을 제어할 수 있는 구조를 마련

## 새로 배운 점

- 단순히 시맨틱 태그만 쓰는 것보다, **숨김 텍스트(`.visuallyHidden`)와 같은 접근성 보조 클래스**를 활용해 실제 사용자 경험을 개선할 수 있음을 확인함
- 모달이나 툴팁처럼 동적으로 나타나는 요소는 **닫기 버튼, 포커스 제어, 보조 텍스트 제공**이 필수적이라는 점을 체감함
- 버튼, 카운터, 네비게이션처럼 반복적으로 쓰이는 UI는 **포커스 가능 여부와 대체 텍스트 제공 여부**가 접근성을 좌우함  
- 접근성을 위한 코드는 단순 보조가 아니라, **UI/UX 품질을 높이는 핵심 요소**라는 걸 배움

## 🧐 우리 팀의 접근성 체크리스트

### `랜딩페이지` -> `프로젝트 탐색` -> `프로젝트 상세 정보` -> `아티클 탐색`

### 랜딩페이지
- 랜딩페이지 내용을 스크린 리더 사용자가 인지할 수 있는가?
- 모든 버튼에 키보드 포커스를 적절하게 제공하고 있는가?
- 랜딩페이지 내용을 건너뛰고 다음 단계로 쉽게 이동 가능한가?

### 프로젝트 탐색
- 스크린 리더 사용자가 검색어를 입력하고 검색 결과 목록을 확인할 수 있는가?
- 검색 필터 옵션들의 의미를 모든 사용자가 명확하게 이해할 수 있는가?
- 정렬 옵션들의 의미를 모든 사용자가 명확하게 이해할 수 있는가?
- 스크린 리더 사용자가 프로젝트의 overview 정보를 인지할 수 있는가?
- 키보드를 사용해서 최상단으로 이동할 수 있는가?
- 키보드 포커스 상태를 시각적으로 인지할 수 있는가?

### 프로젝트 상세 정보
- 보이스오버 사용자가 캐러셀 요소가 몇 개인지 파악 가능한가?
- 아티클에 대한 내용이 스크린 리더에 이해할 수 있게 읽히는지?
- 프로젝트 아티클 탭을 키보드로 이용할 수 있는지? (스크린 리더로 읽으면 이해할 수 있는지?)

### 아티클 탐색
- 필터링/정렬/검색 기능 조작 UI에 적절한 레이블(label 또는 aria-label)이 있는가?
- 필터링/정렬/검색 기능 키보드만으로 필터/정렬/검색 입력 및 적용이 가능한가?
- 아티클로 이동을 할 때 새창이 띄어진다는 것을 사용자가 알 수 있는가?
- 아티클 섹션이 선택이 되면 스크린 리더에서 어떤 아티클인지 사용자가 정보를 얻을 수 있는가?
- 무한스크롤을 이용해서 더 많은 아티클을 불러오는데 스크린리더를 사용하는 사람이 맥락을 알 수 있는가?
- 검색 결과가 없을 경우 스크린 리더가 위와 같은 정보를 동일하게 얻을 수 있는가?